### PR TITLE
Use renovate: keep deps up2date :recycle: 

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>axonivy/renovate-config",
+    "schedule:earlyMondays"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames" :[
+        "org.apache.maven.*",
+        "org.junit.jupiter:*",
+        "org.assertj:*"
+      ],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
just saw that I missed a new release of langChain4j, with cool new features like "thinking" :wink: 
https://github.com/langchain4j/langchain4j/releases

So I think it's time to automatically update our dependencies. 
Renovate is like dependabot, just cooler and with more features. 