### PR TITLE
Added permissions for Github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
     - cron:  '21 21 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v6

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -6,6 +6,11 @@ on:
     - cron:  '21 21 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v6

--- a/.github/workflows/publish-release-drafter.yml
+++ b/.github/workflows/publish-release-drafter.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   publish_release_drafter:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,6 +9,10 @@ on:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release_drafter:
     uses: axonivy-market/github-workflows/.github/workflows/release-drafter.yml@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
         default: 13.2.0-a1
         description: the release to introduce (e.g. a1/b2)
 
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/release.yml@v6


### PR DESCRIPTION
Code scanning has reported warnings related to GitHub workflows.

<img width="1677" height="831" alt="image" src="https://github.com/user-attachments/assets/a039d443-a5cb-4d00-9afc-a052fb68588a" />

After analyzing the issue and discussing it with the Octopus team, we concluded that we should align with the changes in the following pull request to resolve the problem:
https://github.com/axonivy-market/market-product/pull/51

These fixes applied to open repositories. This repository was not updated earlier because it was initially created as a private repository.