### PR TITLE
Move OpenAI variables; setup like any model provider

### DIFF
--- a/smart-workflow/config/variables.yaml
+++ b/smart-workflow/config/variables.yaml
@@ -1,14 +1,15 @@
 # yaml-language-server: $schema=https://json-schema.axonivy.com/app/13.2.1/variables.json
 Variables:
   AI:
-    OpenAI:
-      #[password]
-      APIKey: ${decrypt:}
-      BaseUrl: ""
-      # The default model, if not explicitly specified on the calling Agent.
-      #
-      # See dev.langchain4j.model.openai.OpenAiChatModelName for the list of all supported models
-      # [enum: gpt-4o, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, gpt-5]
-      Model: ""
+    Providers:
+      OpenAI:
+        #[password]
+        APIKey: ${decrypt:}
+        BaseUrl: ""
+        # The default model, if not explicitly specified on the calling Agent.
+        #
+        # See dev.langchain4j.model.openai.OpenAiChatModelName for the list of all supported models
+        # [enum: gpt-4o, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, gpt-5]
+        Model: ""
     # [enum: OpenAI]
     DefaultProvider: ""

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/model/openai/internal/OpenAiServiceConnector.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/model/openai/internal/OpenAiServiceConnector.java
@@ -25,7 +25,7 @@ public class OpenAiServiceConnector {
   private static final String DEFAULT_MODEL = OpenAiChatModelName.GPT_4_1_MINI.toString();
 
   public interface OpenAiConf {
-    String PREFIX = "Ai.OpenAI.";
+    String PREFIX = "Ai.Providers.OpenAI.";
     String BASE_URL = PREFIX + "BaseUrl";
     String API_KEY = PREFIX + "APIKey";
     String MODEL = PREFIX + "Model";


### PR DESCRIPTION
Breaks existing configs; so that we can setup OpenAI like any other vendor.