### PR TITLE
Introduce an E2E test: calling OpenAI for structured-output :test_tube: :calling: 

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,18 @@
+name: E2E-Build
+
+on:
+  schedule:
+    - cron:  '0 1 * * 0' # 1 AM on Sunday
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  build:
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v6
+    with:
+      mvnArgs: -P e2e.test 
+    secrets:
+      mvnArgs: -DOPEN_AI_API_KEY=${{ secrets.OPEN_AI_API_KEY }}

--- a/smart-workflow-test/config/users.xml
+++ b/smart-workflow-test/config/users.xml
@@ -1,2 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<userConfig/>
+<userConfig>
+    <user>
+        <username>James</username>
+        <password>secret</password>
+        <fullName>James Bond</fullName>
+        <emailAddress>007@gov.co.uk</emailAddress>
+    </user>
+</userConfig>

--- a/smart-workflow-test/pom.xml
+++ b/smart-workflow-test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
@@ -60,4 +60,37 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>e2e.test</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>integration-test</id>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>verify</id>
+                <goals>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/openai/OpenAiModelIT.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/openai/OpenAiModelIT.java
@@ -1,0 +1,47 @@
+package com.axonivy.utils.smart.workflow.model.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.axonivy.utils.smart.workflow.model.ChatModelFactory.AiConf;
+import com.axonivy.utils.smart.workflow.model.openai.internal.OpenAiServiceConnector.OpenAiConf;
+import com.axonivy.utils.smart.workflow.test.TestToolUserData;
+
+import ch.ivyteam.ivy.bpm.engine.client.BpmClient;
+import ch.ivyteam.ivy.bpm.engine.client.element.BpmProcess;
+import ch.ivyteam.ivy.bpm.exec.client.IvyProcessTest;
+import ch.ivyteam.ivy.environment.AppFixture;
+import ch.ivyteam.ivy.environment.Ivy;
+import ch.ivyteam.test.log.LoggerAccess;
+import dev.langchain4j.http.client.log.LoggingHttpClient;
+
+@IvyProcessTest
+class OpenAiModelIT {
+
+  private static final BpmProcess AGENT_TOOLS = BpmProcess.name("TestToolUser");
+
+  @RegisterExtension
+  LoggerAccess log = new LoggerAccess(LoggingHttpClient.class.getName());
+
+  @BeforeEach
+  void setup(AppFixture fixture) {
+    fixture.var(AiConf.DEFAULT_PROVIDER, OpenAiModelProvider.NAME); // enforce OpenAI!
+    fixture.var(OpenAiConf.API_KEY, System.getProperty("OPEN_AI_API_KEY", System.getenv("OPEN_AI_API_KEY")));
+  }
+
+  @Test
+  void structuredOutput_e2e(BpmClient client) {
+    Ivy.session().loginSessionUser("James", "secret");
+    var res = client.start()
+        .process(AGENT_TOOLS.elementName("structuredOutput"))
+        .as().session(Ivy.session())
+        .execute();
+    TestToolUserData data = res.data().last();
+    assertThat(data.getPerson().getFirstName())
+        .isEqualTo("James");
+  }
+
+}

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/model/ChatModelFactory.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/model/ChatModelFactory.java
@@ -16,8 +16,12 @@ import dev.langchain4j.model.chat.ChatModel;
 
 public class ChatModelFactory {
 
+  public interface AiConf {
+    String DEFAULT_PROVIDER = "AI.DefaultProvider";
+  }
+
   public static ChatModel createModel(ModelOptions modelOptions) {
-    String vendor = Optional.ofNullable(Ivy.var().get("AI.DefaultProvider"))
+    String vendor = Optional.ofNullable(Ivy.var().get(AiConf.DEFAULT_PROVIDER))
         .filter(Predicate.not(String::isEmpty))
         .orElse("OpenAI");
     var provider = ChatModelFactory.create(vendor)


### PR DESCRIPTION
As discussed; a first end2end test for OpenAI :
- by intention we fire only a single test with very deterministic results ... the goal is not to cover every corner case of the demos. But to use once the real LLM over its official endpoint, with zero mocks in charge. 