### PR TITLE
Azure OpenAI as dedicated installable add-on

### DIFF
--- a/smart-workflow-product/product.json
+++ b/smart-workflow-product/product.json
@@ -18,6 +18,13 @@
             "version": "${version}",
             "type": "iar",
             "importInWorkspace": true
+          },
+          {
+            "groupId": "com.axonivy.utils.ai",
+            "artifactId": "smart-workflow-azure-openai",
+            "version": "${version}",
+            "type": "iar",
+            "importInWorkspace": false
           }
         ],
         "repositories": [


### PR DESCRIPTION
azure-openai as installable product, but un-selected by default ... so users have to opt-in

<img width="607" height="362" alt="smart-installer" src="https://github.com/user-attachments/assets/4f324aab-d909-43f3-8798-f165d5799412" />
