### PR TITLE
AIAI-371 Standardize guardrail collection logic

### DIFF
--- a/doc/GUARDRAILS.md
+++ b/doc/GUARDRAILS.md
@@ -11,7 +11,7 @@ Guardrails protect AI agents by validating both user input and AI output. Smart 
 
 ## Configuring Default Guardrails
 
-Set default guardrails in `variables.yaml`:
+Set default guardrails in `variables.yaml`. These apply to every agent that does **not** explicitly configure its own guardrail list:
 
 ```yaml
 Variables:

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/extraction/internal/TestFileExtractionDemo.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/extraction/internal/TestFileExtractionDemo.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import com.axonivy.utils.ai.mock.MockOpenAI;
 import com.axonivy.utils.smart.workflow.client.OpenAiTestClient;
-import com.axonivy.utils.smart.workflow.guardrails.provider.DefaultGuardrailProvider;
+import com.axonivy.utils.smart.workflow.guardrails.GuardrailCollector;
 import com.axonivy.utils.smart.workflow.model.openai.internal.OpenAiServiceConnector.OpenAiConf;
 
 import Features.FileExtractionDemoData;
@@ -25,7 +25,7 @@ class TestFileExtractionDemo {
   void setup(AppFixture fixture, ResourceResponder responder) {
     fixture.var(OpenAiConf.BASE_URL, OpenAiTestClient.localMockApiUrl("extraction"));
     fixture.var(OpenAiConf.API_KEY, "");
-    fixture.var(DefaultGuardrailProvider.DEFAULT_INPUT_GUARDRAILS, "");
+    fixture.var(GuardrailCollector.DEFAULT_INPUT_GUARDRAILS, "");
     MockOpenAI.defineChat(_ -> responder.send("response.json"));
   }
 

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestGuardrailCollector.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestGuardrailCollector.java
@@ -16,7 +16,6 @@ import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowInputGuar
 import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowOutputGuardrail;
 import com.axonivy.utils.smart.workflow.guardrails.input.PromptInjectionInputGuardrail;
 import com.axonivy.utils.smart.workflow.guardrails.output.SensitiveDataOutputGuardrail;
-import com.axonivy.utils.smart.workflow.guardrails.provider.DefaultGuardrailProvider;
 
 import ch.ivyteam.ivy.environment.AppFixture;
 import ch.ivyteam.ivy.environment.IvyTest;
@@ -26,25 +25,32 @@ public class TestGuardrailCollector {
 
   @BeforeEach
   void setup(AppFixture fixture) {
-    fixture.var(DefaultGuardrailProvider.DEFAULT_INPUT_GUARDRAILS, "PromptInjectionInputGuardrail");
-    fixture.var(DefaultGuardrailProvider.DEFAULT_OUTPUT_GUARDRAILS, "SensitiveDataOutputGuardrail");
+    fixture.var(GuardrailCollector.DEFAULT_INPUT_GUARDRAILS, "PromptInjectionInputGuardrail");
+    fixture.var(GuardrailCollector.DEFAULT_OUTPUT_GUARDRAILS, "SensitiveDataOutputGuardrail");
   }
 
   @Test
-  void inputProvidersListWithoutFilters(AppFixture fixture) {
+  void inputAdaptersWithVariableDefault() {
     var adapters = GuardrailCollector.inputGuardrailAdapters(null);
     assertThat(adapters).hasSize(1);
     assertThat(adapters.get(0).getDelegate()).isInstanceOf(PromptInjectionInputGuardrail.class);
   }
 
   @Test
-  void inputProvidersListWithFilters() {
+  void inputAdaptersWithEmptyVariable(AppFixture fixture) {
+    fixture.var(GuardrailCollector.DEFAULT_INPUT_GUARDRAILS, "");
+    assertThat(GuardrailCollector.inputGuardrailAdapters(null)).isEmpty();
+  }
+
+  @Test
+  void inputAdaptersWithFilters() {
+    // Filter order preserved; duplicates/unknowns silently ignored
     var adapters = GuardrailCollector.inputGuardrailAdapters(
-        List.of("PromptInjectionInputGuardrail", "PromptInjectionInputGuardrail", "InvalidGuardrail", "DummyInputGuardrail", "SecondDummyInputGuardrail"));
-    assertThat(adapters).hasSize(3); // duplicates and non-existed should be filtered
+        List.of("DummyInputGuardrail", "PromptInjectionInputGuardrail", "PromptInjectionInputGuardrail", "InvalidGuardrail", "SecondDummyInputGuardrail"));
+    assertThat(adapters).hasSize(3);
     List<SmartWorkflowInputGuardrail> delegates = adapters.stream().map(InputGuardrailAdapter::getDelegate).toList();
-    assertThat(delegates.get(0)).isInstanceOf(PromptInjectionInputGuardrail.class);
-    assertThat(delegates.get(1)).isInstanceOf(DummyInputGuardrail.class);
+    assertThat(delegates.get(0)).isInstanceOf(DummyInputGuardrail.class);
+    assertThat(delegates.get(1)).isInstanceOf(PromptInjectionInputGuardrail.class);
     assertThat(delegates.get(2)).isInstanceOf(SecondDummyInputGuardrail.class);
   }
 
@@ -56,20 +62,21 @@ public class TestGuardrailCollector {
   }
 
   @Test
-  void outputProvidersListWithoutFilters() {
+  void outputAdaptersWithVariableDefault() {
     var adapters = GuardrailCollector.outputGuardrailAdapters(null);
     assertThat(adapters).hasSize(1);
     assertThat(adapters.get(0).getDelegate()).isInstanceOf(SensitiveDataOutputGuardrail.class);
   }
 
   @Test
-  void outputProvidersListWithFilters() {
+  void outputAdaptersWithFilters() {
+    // Filter order preserved; duplicates/unknowns silently ignored
     var adapters = GuardrailCollector.outputGuardrailAdapters(
-        List.of("SensitiveDataOutputGuardrail", "SensitiveDataOutputGuardrail", "InvalidGuardrail", "DummyOutputGuardrail", "SecondDummyOutputGuardrail"));
-    assertThat(adapters).hasSize(3); // duplicates and non-existed should be filtered
+        List.of("DummyOutputGuardrail", "SensitiveDataOutputGuardrail", "SensitiveDataOutputGuardrail", "InvalidGuardrail", "SecondDummyOutputGuardrail"));
+    assertThat(adapters).hasSize(3);
     List<SmartWorkflowOutputGuardrail> delegates = adapters.stream().map(OutputGuardrailAdapter::getDelegate).toList();
-    assertThat(delegates.get(0)).isInstanceOf(SensitiveDataOutputGuardrail.class);
-    assertThat(delegates.get(1)).isInstanceOf(DummyOutputGuardrail.class);
+    assertThat(delegates.get(0)).isInstanceOf(DummyOutputGuardrail.class);
+    assertThat(delegates.get(1)).isInstanceOf(SensitiveDataOutputGuardrail.class);
     assertThat(delegates.get(2)).isInstanceOf(SecondDummyOutputGuardrail.class);
   }
 

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestOutputGuardrailProcess.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestOutputGuardrailProcess.java
@@ -9,7 +9,7 @@ import javax.ws.rs.core.Response;
 
 import com.axonivy.utils.ai.mock.MockOpenAI;
 import com.axonivy.utils.smart.workflow.client.OpenAiTestClient;
-import com.axonivy.utils.smart.workflow.guardrails.provider.DefaultGuardrailProvider;
+import com.axonivy.utils.smart.workflow.guardrails.GuardrailCollector;
 import com.axonivy.utils.smart.workflow.model.openai.internal.OpenAiServiceConnector.OpenAiConf;
 
 import Features.GuardrailDemoData;
@@ -27,7 +27,7 @@ public class TestOutputGuardrailProcess {
   void setup(AppFixture fixture) {
     fixture.var(OpenAiConf.BASE_URL, OpenAiTestClient.localMockApiUrl("guardrails"));
     fixture.var(OpenAiConf.API_KEY, "");
-    fixture.var(DefaultGuardrailProvider.DEFAULT_OUTPUT_GUARDRAILS, "");
+    fixture.var(GuardrailCollector.DEFAULT_OUTPUT_GUARDRAILS, "");
     MockOpenAI.defineChat(_ -> buildResponse());
   }
 

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/output/TestMultiModelsOutput.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/output/TestMultiModelsOutput.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.axonivy.utils.ai.mock.MockOpenAI;
 import com.axonivy.utils.smart.workflow.client.OpenAiTestClient;
-import com.axonivy.utils.smart.workflow.guardrails.provider.DefaultGuardrailProvider;
+import com.axonivy.utils.smart.workflow.guardrails.GuardrailCollector;
 import com.axonivy.utils.smart.workflow.model.ChatModelFactory.AiConf;
 import com.axonivy.utils.smart.workflow.model.dummy.DummyChatModelProvider;
 import com.axonivy.utils.smart.workflow.model.openai.internal.OpenAiServiceConnector.OpenAiConf;
@@ -40,7 +40,7 @@ public class TestMultiModelsOutput {
     fixture.var(OpenAiConf.API_KEY, "");
     fixture.var(AiConf.DEFAULT_PROVIDER, "");
     fixture.var(OpenAiConf.DEFAULT_MODEL, "");
-    fixture.var(DefaultGuardrailProvider.DEFAULT_INPUT_GUARDRAILS, "");
+    fixture.var(GuardrailCollector.DEFAULT_INPUT_GUARDRAILS, "");
 
     DummyChatModelProvider.defineChatText(_ -> "The Spark of Innovation");
   }

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/GuardrailCollector.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/GuardrailCollector.java
@@ -1,24 +1,28 @@
 package com.axonivy.utils.smart.workflow.guardrails;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.axonivy.utils.smart.workflow.guardrails.adapter.AbstractGuardrailAdapter;
 import com.axonivy.utils.smart.workflow.guardrails.adapter.InputGuardrailAdapter;
 import com.axonivy.utils.smart.workflow.guardrails.adapter.OutputGuardrailAdapter;
 import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowGuardrail;
-import com.axonivy.utils.smart.workflow.guardrails.provider.DefaultGuardrailProvider;
 import com.axonivy.utils.smart.workflow.guardrails.provider.GuardrailProvider;
 import com.axonivy.utils.smart.workflow.spi.internal.SpiLoader;
 import com.axonivy.utils.smart.workflow.spi.internal.SpiProject;
 
+import ch.ivyteam.ivy.environment.Ivy;
+
 public class GuardrailCollector {
+  public static final String DEFAULT_INPUT_GUARDRAILS = "AI.Guardrails.DefaultInput";
+  public static final String DEFAULT_OUTPUT_GUARDRAILS = "AI.Guardrails.DefaultOutput";
 
   public static Set<GuardrailProvider> allProviders() {
     var project = SpiProject.getSmartWorkflowPmv().project();
@@ -26,63 +30,65 @@ public class GuardrailCollector {
   }
 
   public static List<String> allInputGuardrailNames() {
-    return allGuardrailNames(
-        new DefaultGuardrailProvider().getInputGuardrails(),
-        GuardrailProvider::getInputGuardrails);
+    return allGuardrailNames(GuardrailProvider::getInputGuardrails);
   }
 
   public static List<InputGuardrailAdapter> inputGuardrailAdapters(List<String> filters) {
     return guardrailAdapters(filters,
-        new DefaultGuardrailProvider().getFilteredDefaultInputGuardrails(),
+        DEFAULT_INPUT_GUARDRAILS,
         GuardrailProvider::getInputGuardrails,
         InputGuardrailAdapter::new);
   }
 
   public static List<String> allOutputGuardrailNames() {
-    return allGuardrailNames(
-        new DefaultGuardrailProvider().getOutputGuardrails(),
-        GuardrailProvider::getOutputGuardrails);
+    return allGuardrailNames(GuardrailProvider::getOutputGuardrails);
   }
 
   public static List<OutputGuardrailAdapter> outputGuardrailAdapters(List<String> filters) {
     return guardrailAdapters(filters,
-        new DefaultGuardrailProvider().getFilteredDefaultOutputGuardrails(),
+        DEFAULT_OUTPUT_GUARDRAILS,
         GuardrailProvider::getOutputGuardrails,
         OutputGuardrailAdapter::new);
   }
 
   private static <G extends SmartWorkflowGuardrail> List<String> allGuardrailNames(
-      List<G> defaults,
       Function<GuardrailProvider, List<G>> providerExtractor) {
-    List<G> guardrails = new ArrayList<>(defaults);
-    allProviders().stream()
+    Set<String> uniqueNames = allProviders().stream()
         .flatMap(p -> providerExtractor.apply(p).stream())
-        .forEach(guardrails::add);
-    return new ArrayList<>(guardrails.stream()
         .map(SmartWorkflowGuardrail::name)
-        .collect(Collectors.toCollection(LinkedHashSet::new)));
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+    return List.copyOf(uniqueNames);
   }
 
   private static <G extends SmartWorkflowGuardrail, A extends AbstractGuardrailAdapter<G>> List<A> guardrailAdapters(
       List<String> filters,
-      List<G> defaults,
+      String defaultVariableKey,
       Function<GuardrailProvider, List<G>> providerExtractor,
       Function<G, A> adapterFactory) {
-    List<G> guardrails = new ArrayList<>(defaults);
 
-    if (CollectionUtils.isEmpty(filters)) {
-      return new ArrayList<>(guardrails.stream()
-          .map(adapterFactory)
-          .collect(Collectors.toCollection(LinkedHashSet::new)));
+    Set<String> requestedNames = new LinkedHashSet<>(
+        (filters != null && !filters.isEmpty()) ? filters : readVariableNames(defaultVariableKey));
+
+    if (requestedNames.isEmpty()) {
+      return List.of();
     }
 
-    allProviders().stream()
+    Map<String, G> guardrailsByName = allProviders().stream()
         .flatMap(p -> providerExtractor.apply(p).stream())
-        .forEach(guardrails::add);
+        .collect(Collectors.toMap(SmartWorkflowGuardrail::name, g -> g, (existing, dup) -> existing));
 
-    return new ArrayList<>(guardrails.stream()
-        .filter(g -> filters.contains(g.name()))
+    return requestedNames.stream()
+        .filter(guardrailsByName::containsKey)
+        .map(guardrailsByName::get)
         .map(adapterFactory)
-        .collect(Collectors.toCollection(LinkedHashSet::new)));
+        .collect(Collectors.toList());
+  }
+
+  private static List<String> readVariableNames(String variableKey) {
+    var configuredValue = StringUtils.defaultString(Ivy.var().get(variableKey));
+    return Arrays.stream(StringUtils.split(configuredValue, ','))
+        .map(String::strip)
+        .filter(StringUtils::isNotBlank)
+        .collect(Collectors.toList());
   }
 }

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/provider/DefaultGuardrailProvider.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/provider/DefaultGuardrailProvider.java
@@ -1,46 +1,13 @@
 package com.axonivy.utils.smart.workflow.guardrails.provider;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
-
-import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowGuardrail;
 import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowInputGuardrail;
 import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowOutputGuardrail;
 import com.axonivy.utils.smart.workflow.guardrails.input.PromptInjectionInputGuardrail;
 import com.axonivy.utils.smart.workflow.guardrails.output.SensitiveDataOutputGuardrail;
 
-import ch.ivyteam.ivy.environment.Ivy;
-
 public class DefaultGuardrailProvider implements GuardrailProvider {
-  public static final String DEFAULT_INPUT_GUARDRAILS = "AI.Guardrails.DefaultInput";
-  public static final String DEFAULT_OUTPUT_GUARDRAILS = "AI.Guardrails.DefaultOutput";
-
-  public List<SmartWorkflowInputGuardrail> getFilteredDefaultInputGuardrails() {
-    return getGuardrailsByVariableKey(DEFAULT_INPUT_GUARDRAILS, getInputGuardrails());
-  }
-
-  public List<SmartWorkflowOutputGuardrail> getFilteredDefaultOutputGuardrails() {
-    return getGuardrailsByVariableKey(DEFAULT_OUTPUT_GUARDRAILS, getOutputGuardrails());
-  }
-
-  private <T extends SmartWorkflowGuardrail> List<T> getGuardrailsByVariableKey(String variableKey,
-      List<T> guardrails) {
-    String defaultGuardrails = "";
-    try {
-      defaultGuardrails = StringUtils.defaultString(Ivy.var().get(variableKey));
-    } catch (Exception e) {
-      Ivy.log().error("Error reading default guardrails for variable key '" + variableKey + "'", e);
-    }
-    String[] split = StringUtils.split(defaultGuardrails, ",");
-    Set<String> guardrailNames = split == null ? Set.of()
-        : Arrays.stream(split).filter(StringUtils::isNotBlank).map(String::strip).collect(Collectors.toSet());
-    return guardrails.stream().filter(g -> guardrailNames.contains(g.name())).collect(Collectors.toList());
-  }
-
   @Override
   public List<SmartWorkflowInputGuardrail> getInputGuardrails() {
     return List.of(new PromptInjectionInputGuardrail());

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/program/internal/AgentCallExecutor.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/program/internal/AgentCallExecutor.java
@@ -128,10 +128,8 @@ public class AgentCallExecutor {
 
   private void configureGuardrails(AiServices<? extends DynamicAgent<?>> agentBuilder) {
     List<String> inputGuardrailFilters = executeListOfStrings(Conf.INPUT_GUARD_RAILS).orElse(null);
-    GuardrailCollector.inputGuardrailAdapters(inputGuardrailFilters)
-      .forEach(agentBuilder::inputGuardrails);
+    agentBuilder.inputGuardrails(GuardrailCollector.inputGuardrailAdapters(inputGuardrailFilters));
     List<String> outputGuardrailFilters = executeListOfStrings(Conf.OUTPUT_GUARD_RAILS).orElse(null);
-    GuardrailCollector.outputGuardrailAdapters(outputGuardrailFilters)
-      .forEach(agentBuilder::outputGuardrails);
+    agentBuilder.outputGuardrails(GuardrailCollector.outputGuardrailAdapters(outputGuardrailFilters));
   }
 }

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/program/internal/AgentEditor.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/program/internal/AgentEditor.java
@@ -92,22 +92,14 @@ public class AgentEditor {
   }
 
   private String inputGuardrailsList() {
-    var guardrails = Optional.ofNullable(GuardrailCollector.allInputGuardrailNames());
-    if (guardrails.isEmpty()) {
-      return StringUtils.EMPTY;
-    }
-    return guardrails.get().stream()
-      .map(guardrail -> String.format("- %s", guardrail))
-      .collect(Collectors.joining("\n"));
+    return GuardrailCollector.allInputGuardrailNames().stream()
+        .map(name -> "- " + name)
+        .collect(Collectors.joining("\n"));
   }
 
   private String outputGuardrailsList() {
-    var guardrails = Optional.ofNullable(GuardrailCollector.allOutputGuardrailNames());
-    if (guardrails.isEmpty()) {
-      return StringUtils.EMPTY;
-    }
-    return guardrails.get().stream()
-      .map(guardrail -> String.format("- %s", guardrail))
-      .collect(Collectors.joining("\n"));
+    return GuardrailCollector.allOutputGuardrailNames().stream()
+        .map(name -> "- " + name)
+        .collect(Collectors.joining("\n"));
   }
 }


### PR DESCRIPTION
## Pull request overview

Standardizes how guardrails are selected for agents: prefer explicitly configured guardrail names; if empty, fall back to defaults from `variables.yaml`; if still empty, apply no guardrails. The collector now resolves guardrails via SPI and applies them in the configured order.

**Changes:**
- Reworked `GuardrailCollector` to resolve guardrails by configured names (config list → variable default → none) and preserve configured order.
- Simplified agent configuration and UI listing to rely on the collector’s unified logic.
- Updated tests/docs to reference the new default-variable constants location and behavior.