### PR TITLE
Dynamically load secrets to protect from any Model provider :closed_lock_with_key:  

### DIFF
--- a/models/smart-workflow-anthropic/src/com/axonivy/utils/smart/workflow/model/anthropic/AnthropicModelProvider.java
+++ b/models/smart-workflow-anthropic/src/com/axonivy/utils/smart/workflow/model/anthropic/AnthropicModelProvider.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import com.axonivy.utils.smart.workflow.model.anthropic.internal.AnthropicServiceConnector;
+import com.axonivy.utils.smart.workflow.model.anthropic.internal.AnthropicServiceConnector.AnthropicConf;
 import com.axonivy.utils.smart.workflow.model.spi.ChatModelProvider;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModelName;
@@ -34,6 +35,11 @@ public class AnthropicModelProvider implements ChatModelProvider {
     return Stream.of(AnthropicChatModelName.values())
       .map(AnthropicChatModelName::toString)
       .toList();
+  }
+
+  @Override
+  public List<String> secretsVars() {
+    return List.of(AnthropicConf.API_KEY);
   }
   
 }

--- a/models/smart-workflow-azure-openai/src/com/axonivy/utils/smart/workflow/model/azureopenai/AzureOpenAiModelProvider.java
+++ b/models/smart-workflow-azure-openai/src/com/axonivy/utils/smart/workflow/model/azureopenai/AzureOpenAiModelProvider.java
@@ -5,6 +5,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
+
+import com.axonivy.utils.smart.workflow.model.azureopenai.internal.AzureOpenAiConf;
 import com.axonivy.utils.smart.workflow.model.azureopenai.internal.AzureOpenAiServiceConnector;
 import com.axonivy.utils.smart.workflow.model.azureopenai.internal.entity.AzureAiDeployment;
 import com.axonivy.utils.smart.workflow.model.azureopenai.internal.utils.VariableUtils;
@@ -41,5 +44,14 @@ public class AzureOpenAiModelProvider implements ChatModelProvider {
   public List<String> models() {
     return Optional.ofNullable(VariableUtils.getDeployments()).orElse(new ArrayList<>()).stream()
         .map(AzureAiDeployment::getName).collect(Collectors.toList());
+  }
+
+  @Override
+  public List<String> secretsVars() {
+    return VariableUtils.deploymentsVars().stream()
+      .map(var -> StringUtils.substringBeforeLast(var.name(), "."))
+      .distinct()
+      .map(var -> var + "." + AzureOpenAiConf.API_KEY_FIELD)
+      .toList();
   }
 }

--- a/models/smart-workflow-azure-openai/src/com/axonivy/utils/smart/workflow/model/azureopenai/internal/utils/VariableUtils.java
+++ b/models/smart-workflow-azure-openai/src/com/axonivy/utils/smart/workflow/model/azureopenai/internal/utils/VariableUtils.java
@@ -17,16 +17,12 @@ import ch.ivyteam.ivy.vars.Variable;
 public final class VariableUtils {
 
   public static List<AzureAiDeployment> getDeployments() {
-    List<Variable> deploymentVariables = Ivy.var().all().stream()
-        .filter(variable -> variable.name().startsWith(AzureOpenAiConf.DEPLOYMENTS))
-        .filter(variable -> !variable.name().equals(AzureOpenAiConf.DEPLOYMENTS)).collect(Collectors.toList());
-
-    if (deploymentVariables.size() == 0) {
-      return null;
+    var deploymentVars = deploymentsVars();
+    if (deploymentVars.isEmpty()) {
+      return List.of();
     }
-
     Map<String, AzureAiDeployment> deploymentMap = new HashMap<>();
-    for (Variable variable : deploymentVariables) {
+    for (Variable variable : deploymentVars) {
       String[] parts = variable.name().split("\\.");
       if (parts.length == 6) {
         String deploymentName = parts[4];
@@ -43,7 +39,14 @@ public final class VariableUtils {
 
     return deploymentMap.values().stream()
         .filter(deployment -> deployment.getName() != null && !deployment.getName().isEmpty())
-        .collect(Collectors.toList());
+        .toList();
+  }
+
+  public static List<Variable> deploymentsVars(){
+    return Ivy.var().all().stream()
+        .filter(variable -> variable.name().startsWith(AzureOpenAiConf.DEPLOYMENTS))
+        .filter(variable -> !variable.name().equals(AzureOpenAiConf.DEPLOYMENTS))
+        .toList();
   }
 
   public static AzureAiDeployment getDeploymentByName(String deploymentName) {

--- a/models/smart-workflow-gemini/src/com/axonivy/utils/smart/workflow/model/gemini/GeminiModelProvider.java
+++ b/models/smart-workflow-gemini/src/com/axonivy/utils/smart/workflow/model/gemini/GeminiModelProvider.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import com.axonivy.utils.smart.workflow.model.gemini.internal.GeminiServiceConnector;
+import com.axonivy.utils.smart.workflow.model.gemini.internal.GeminiServiceConnector.GeminiConf;
 import com.axonivy.utils.smart.workflow.model.gemini.internal.enums.GoogleAiGeminiChatModelName;
 import com.axonivy.utils.smart.workflow.model.spi.ChatModelProvider;
 
@@ -37,6 +38,11 @@ public class GeminiModelProvider implements ChatModelProvider {
     return Stream.of(GoogleAiGeminiChatModelName.values())
         .map(GoogleAiGeminiChatModelName::toString)
         .toList();
+  }
+
+  @Override
+  public List<String> secretsVars() {
+    return List.of(GeminiConf.API_KEY);
   }
 
 }

--- a/models/smart-workflow-openai/src/com/axonivy/utils/smart/workflow/model/openai/OpenAiModelProvider.java
+++ b/models/smart-workflow-openai/src/com/axonivy/utils/smart/workflow/model/openai/OpenAiModelProvider.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import com.axonivy.utils.smart.workflow.model.openai.internal.OpenAiServiceConnector;
+import com.axonivy.utils.smart.workflow.model.openai.internal.OpenAiServiceConnector.OpenAiConf;
 import com.axonivy.utils.smart.workflow.model.spi.ChatModelProvider;
 
 import dev.langchain4j.model.chat.ChatModel;
@@ -33,6 +34,11 @@ public class OpenAiModelProvider implements ChatModelProvider {
     return Stream.of(OpenAiChatModelName.values())
         .map(OpenAiChatModelName::name)
         .toList();
+  }
+
+  @Override
+  public List<String> secretsVars() {
+    return List.of(OpenAiConf.API_KEY);
   }
 
 }

--- a/models/smart-workflow-xai/src/com/axonivy/utils/smart/workflow/model/xai/XAiModelProvider.java
+++ b/models/smart-workflow-xai/src/com/axonivy/utils/smart/workflow/model/xai/XAiModelProvider.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import com.axonivy.utils.smart.workflow.model.spi.ChatModelProvider;
 import com.axonivy.utils.smart.workflow.model.xai.internal.XAiServiceConnector;
+import com.axonivy.utils.smart.workflow.model.xai.internal.XAiServiceConnector.XAiConf;
+
 import static com.axonivy.utils.smart.workflow.model.xai.internal.XAiServiceConnector.SUPPORTED_MODELS;
 
 import dev.langchain4j.model.chat.Capability;
@@ -33,6 +35,11 @@ public class XAiModelProvider implements ChatModelProvider {
   @Override
   public List<String> models() {
     return SUPPORTED_MODELS;
+  }
+
+  @Override
+  public List<String> secretsVars() {
+    return List.of(XAiConf.API_KEY);
   }
 
 }

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestSensitiveDataOutputGuardrail.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestSensitiveDataOutputGuardrail.java
@@ -13,7 +13,7 @@ import ch.ivyteam.ivy.environment.AppFixture;
 @IvyProcessTest
 public class TestSensitiveDataOutputGuardrail {
 
-  private static final String OPENAI_API_KEY_VAR = "Ai.Providers.OpenAI.APIKey";
+  private static final String OPENAI_API_KEY_VAR = "AI.Providers.OpenAI.APIKey";
   private static final String TEST_API_KEY = "my-custom-secret-key-that-matches-no-regex";
 
   private SensitiveDataOutputGuardrail guardrail;
@@ -130,7 +130,7 @@ public class TestSensitiveDataOutputGuardrail {
   @Test
   void blockConfiguredApiKey(AppFixture fixture) {
     fixture.var(OPENAI_API_KEY_VAR, TEST_API_KEY);
-    var result = guardrail.evaluate("Here is the configured key: " + TEST_API_KEY);
+    var result = new SensitiveDataOutputGuardrail().evaluate("Here is the configured key: " + TEST_API_KEY);
     assertThat(result.isAllowed()).isFalse();
     assertThat(result.getReason()).contains("sensitive data");
   }

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/azureopenai/TestAzureOpenAiLoader.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/azureopenai/TestAzureOpenAiLoader.java
@@ -74,4 +74,10 @@ public class TestAzureOpenAiLoader {
   private static ChatModelProvider loadModel() {
     return ChatModelFactory.create(AzureOpenAiModelProvider.NAME).get();
   }
+
+  @Test
+  void secrets_deploymentAware(){
+    assertThat(provider.secretsVars())
+      .contains(DEPLOYMENTS_PREFIX + "." + TEST_DEPLOYMENT_NAME + ".APIKey");
+  }
 }

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/dummy/DummyChatModelProvider.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/dummy/DummyChatModelProvider.java
@@ -29,6 +29,11 @@ public class DummyChatModelProvider implements ChatModelProvider {
   }
 
   @Override
+  public List<String> secretsVars() {
+    return List.of();
+  }
+
+  @Override
   public ChatModel setup(ModelOptions options) {
     return new DummyChatModel(options, options.listeners());
   }

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/output/SensitiveDataOutputGuardrail.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/output/SensitiveDataOutputGuardrail.java
@@ -1,6 +1,5 @@
 package com.axonivy.utils.smart.workflow.guardrails.output;
 
-import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -9,38 +8,35 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailResult;
 import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowOutputGuardrail;
+import com.axonivy.utils.smart.workflow.model.ChatModelFactory;
 
 import ch.ivyteam.ivy.environment.Ivy;
 
 public class SensitiveDataOutputGuardrail implements SmartWorkflowOutputGuardrail {
 
   private static final String FAILURE_MESSAGE = "The AI response was blocked because it contains sensitive data such as API keys or private keys";
-
-  private static final List<String> API_KEY_VARIABLE_PATHS = List.of(
-      "Ai.Providers.OpenAI.APIKey",
-      "AI.Providers.AzureOpenAI.Deployments.Deployment.APIKey",
-      "AI.Providers.Gemini.APIKey",
-      "AI.Providers.xAI.APIKey",
-      "AI.Providers.Anthropic.APIKey"
-  );
   
-  private static final Pattern SK_KEY_PATTERN = Pattern.compile(
-      "\\bsk-(?:[a-zA-Z0-9_]+-)*[a-zA-Z0-9_]{20,}\\b");
+  private interface Patterns {
+    Pattern SK_KEY = Pattern.compile(
+        "\\bsk-(?:[a-zA-Z0-9_]+-)*[a-zA-Z0-9_]{20,}\\b");
+  
+    Pattern AWS_KEY = Pattern.compile(
+        "\\b(?:AKIA|ASIA)[0-9A-Z]{16}\\b");
+  
+    Pattern GITHUB_TOKEN = Pattern.compile(
+        "\\bgh[posr]_[a-zA-Z0-9]{36}\\b|\\bgithub_pat_[a-zA-Z0-9_]{82}\\b");
+  
+    Pattern GOOGLE_API_KEY = Pattern.compile(
+        "\\bAIza[0-9A-Za-z_-]{35}\\b");
+  
+    Pattern XAI_KEY = Pattern.compile(
+        "\\bxai-[a-zA-Z0-9]{50,}\\b");
+  
+    Pattern PRIVATE_KEY = Pattern.compile(
+        "-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----");
+  }
 
-  private static final Pattern AWS_KEY_PATTERN = Pattern.compile(
-      "\\b(?:AKIA|ASIA)[0-9A-Z]{16}\\b");
-
-  private static final Pattern GITHUB_TOKEN_PATTERN = Pattern.compile(
-      "\\bgh[posr]_[a-zA-Z0-9]{36}\\b|\\bgithub_pat_[a-zA-Z0-9_]{82}\\b");
-
-  private static final Pattern GOOGLE_API_KEY_PATTERN = Pattern.compile(
-      "\\bAIza[0-9A-Za-z_-]{35}\\b");
-
-  private static final Pattern XAI_KEY_PATTERN = Pattern.compile(
-      "\\bxai-[a-zA-Z0-9]{50,}\\b");
-
-  private static final Pattern PRIVATE_KEY_PATTERN = Pattern.compile(
-      "-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----");
+  private final Set<String> variables = loadConfiguredApiKeys();
 
   @Override
   public GuardrailResult evaluate(String message) {
@@ -55,22 +51,24 @@ public class SensitiveDataOutputGuardrail implements SmartWorkflowOutputGuardrai
   }
 
   private boolean containsConfiguredApiKey(String message) {
-    return loadConfiguredApiKeys().stream().anyMatch(message::contains);
+    return variables.stream().anyMatch(message::contains);
   }
 
   private static Set<String> loadConfiguredApiKeys() {
-    return API_KEY_VARIABLE_PATHS.stream()
-        .map(path -> Ivy.var().get(path))
-        .filter(StringUtils::isNotBlank)
-        .collect(Collectors.toSet());
+    var secrets = ChatModelFactory.providers().stream()
+      .flatMap(provider -> provider.secretsVars().stream())
+      .map(varName -> Ivy.var().get(varName))
+      .filter(StringUtils::isNotBlank)
+      .collect(Collectors.toSet());
+    return secrets;
   }
 
   private boolean containsPatternMatch(String message) {
-    return SK_KEY_PATTERN.matcher(message).find()
-        || AWS_KEY_PATTERN.matcher(message).find()
-        || GITHUB_TOKEN_PATTERN.matcher(message).find()
-        || GOOGLE_API_KEY_PATTERN.matcher(message).find()
-        || XAI_KEY_PATTERN.matcher(message).find()
-        || PRIVATE_KEY_PATTERN.matcher(message).find();
+    return Patterns.SK_KEY.matcher(message).find()
+        || Patterns.AWS_KEY.matcher(message).find()
+        || Patterns.GITHUB_TOKEN.matcher(message).find()
+        || Patterns.GOOGLE_API_KEY.matcher(message).find()
+        || Patterns.XAI_KEY.matcher(message).find()
+        || Patterns.PRIVATE_KEY.matcher(message).find();
   }
 }

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/model/spi/ChatModelProvider.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/model/spi/ChatModelProvider.java
@@ -10,6 +10,7 @@ public interface ChatModelProvider {
   String name();
   ChatModel setup(ModelOptions options);
   List<String> models();
+  List<String> secretsVars();
 
   public static record ModelOptions(
       String modelName,


### PR DESCRIPTION
maintain secret key exposure as feature of the modelprovider. So the guardrails don't need to be adapted for every new provider.
See https://github.com/axonivy-market/smart-workflow/pull/194#issuecomment-4168077217