### PR TITLE
Introduce nightly releases :sleeping: :package: :ship: 

### DIFF
--- a/.github/workflows/release-dev-template.yml
+++ b/.github/workflows/release-dev-template.yml
@@ -50,7 +50,7 @@ jobs:
 
           mvn --batch-mode \
             -Dmaven.test.skip=true \
-            -DaltDeploymentRepository=github::https://maven.pkg.github.com/axonivy-market/${{ github.event.repository.name }} \
+            -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository_owner }}/${{ github.event.repository.name }} \
             ${goals} ${{ inputs.mvnArgs }}
 
   cleanup-snapshots:

--- a/.github/workflows/release-dev-template.yml
+++ b/.github/workflows/release-dev-template.yml
@@ -43,14 +43,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          goals="release:prepare release:perform"
+          goals="clean deploy"
           if [ "${{ inputs.dryRun }}" = "true" ]; then
-            goals="release:prepare"
+            goals="clean verify"
           fi
 
-          mvn --batch-mode -Darguments="-Dmaven.test.skip=true\
-           -DaltDeploymentRepository=github::https://maven.pkg.github.com/axonivy-market/${{ github.event.repository.name }}"\
-           ${goals} ${{ inputs.mvnArgs }}
+          mvn --batch-mode \
+            -Dmaven.test.skip=true \
+            -DaltDeploymentRepository=github::https://maven.pkg.github.com/axonivy-market/${{ github.event.repository.name }} \
+            ${goals} ${{ inputs.mvnArgs }}
 
   cleanup-snapshots:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-dev-template.yml
+++ b/.github/workflows/release-dev-template.yml
@@ -1,0 +1,111 @@
+name: Release-Build-Dev-Template
+
+permissions:
+  contents: read
+  packages: write
+
+on:
+  workflow_call:
+    inputs:
+      javaVersion:
+        type: number
+        default: 25
+      mvnVersion:
+        type: string
+        default: 3.9.13
+      mvnArgs:
+        type: string
+        required: false
+      dryRun:
+        type: boolean
+        default: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.javaVersion }}
+          distribution: temurin
+          server-id: github
+
+      - name: Setup Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: ${{ inputs.mvnVersion }}
+
+      - name: Build with Maven
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          goals="release:prepare release:perform"
+          if [ "${{ inputs.dryRun }}" = "true" ]; then
+            goals="release:prepare"
+          fi
+
+          mvn --batch-mode -Darguments="-Dmaven.test.skip=true\
+           -DaltDeploymentRepository=github::https://maven.pkg.github.com/axonivy-market/${{ github.event.repository.name }}"\
+           ${goals} ${{ inputs.mvnArgs }}
+
+  cleanup-snapshots:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Keep last 5 Maven snapshots
+        uses: actions/github-script@v7
+        env:
+          DRY_RUN: ${{ inputs.dryRun }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const dryRun = ((process.env.DRY_RUN || 'true').toLowerCase() === 'true');
+
+            core.info(`Dry run: ${dryRun}`);
+
+            const packages = await github.paginate('GET /orgs/{org}/packages', {
+              org: owner,
+              package_type: 'maven',
+              per_page: 100
+            });
+
+            const repoPackages = packages.filter(pkg => pkg.repository && pkg.repository.name === repo);
+            core.info(`Found ${repoPackages.length} Maven packages linked to ${owner}/${repo}`);
+
+            for (const pkg of repoPackages) {
+              const versions = await github.paginate(
+                'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
+                {
+                  org: owner,
+                  package_type: 'maven',
+                  package_name: pkg.name,
+                  per_page: 100
+                }
+              );
+
+              const snapshots = versions
+                .filter(v => (v.name || '').includes('SNAPSHOT'))
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+              // Keep the newest 5 snapshot versions and delete older ones.
+              for (const version of snapshots.slice(5)) {
+                core.info(`${dryRun ? '[DRY RUN] Would delete' : 'Deleting'} ${pkg.name}@${version.name} (${version.created_at})`);
+                if (dryRun) {
+                  continue;
+                }
+                await github.request(
+                  'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
+                  {
+                    org: owner,
+                    package_type: 'maven',
+                    package_name: pkg.name,
+                    package_version_id: version.id
+                  }
+                );
+              }
+            }

--- a/.github/workflows/release-dev-template.yml
+++ b/.github/workflows/release-dev-template.yml
@@ -33,6 +33,8 @@ jobs:
           java-version: ${{ inputs.javaVersion }}
           distribution: temurin
           server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
 
       - name: Setup Maven
         uses: stCarolas/setup-maven@v5

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -13,7 +13,7 @@ on:
 
 permissions:
   contents: read
-  packages: read
+  packages: write
 
 jobs:
   release:

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: true
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   release:
     uses: ./.github/workflows/release-dev-template.yml

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,43 @@
+name: Reusable Dev-Release-Build
+
+on: 
+  schedule:
+    - cron:  '21 21 * * *'
+  workflow_call:
+    inputs:
+      javaVersion:
+        type: number
+        default: 25
+      mvnVersion:
+        type: string
+        default: 3.9.13
+      mvnArgs:
+        type: string
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Java JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ inputs.javaVersion }}
+        distribution: temurin
+        server-id: github
+
+    - name: Setup Maven
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: ${{ inputs.mvnVersion }}
+
+    - name: Build with Maven
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        mvn --batch-mode -Darguments="-Dmaven.test.skip=true\
+         -DaltDeploymentRepository=github::https://maven.pkg.github.com/axonivy-market/${{ github.event.repository.name }}"\
+         release:prepare release:perform ${{ inputs.mvnArgs }}

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,119 +1,19 @@
 name: Release-Build-Dev
 
-permissions:
-  contents: read
-  packages: write
-
-on: 
+on:
   schedule:
-    - cron:  '21 21 * * *'
+    - cron: '21 21 * * *'
   workflow_dispatch:
-  workflow_call:
     inputs:
-      javaVersion:
-        type: number
-        default: 25
-      mvnVersion:
-        type: string
-        default: 3.9.13
-      mvnArgs:
-        type: string
-        required: false
       dryRun:
+        description: Dry run mode for release and cleanup
         type: boolean
+        required: false
         default: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Setup Java JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ inputs.javaVersion }}
-        distribution: temurin
-        server-id: github
-
-    - name: Setup Maven
-      uses: stCarolas/setup-maven@v5
-      with:
-        maven-version: ${{ inputs.mvnVersion }}
-
-    - name: Build with Maven
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        dry_run="${{ github.event_name == 'schedule' && 'false' || inputs.dryRun }}"
-        if [ -z "${dry_run}" ]; then
-          dry_run="true"
-        fi
-
-        goals="release:prepare release:perform"
-        if [ "${dry_run}" = "true" ]; then
-          goals="release:prepare"
-        fi
-
-        mvn --batch-mode -Darguments="-Dmaven.test.skip=true\
-         -DaltDeploymentRepository=github::https://maven.pkg.github.com/axonivy-market/${{ github.event.repository.name }}"\
-         ${goals} ${{ inputs.mvnArgs }}
-
-  cleanup-snapshots:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-    - name: Keep last 5 Maven snapshots
-      uses: actions/github-script@v7
-      env:
-        DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || inputs.dryRun || 'true' }}
-      with:
-        script: |
-          const owner = context.repo.owner;
-          const repo = context.repo.repo;
-          const dryRun = ((process.env.DRY_RUN || 'true').toLowerCase() === 'true');
-
-          core.info(`Dry run: ${dryRun}`);
-
-          const packages = await github.paginate('GET /orgs/{org}/packages', {
-            org: owner,
-            package_type: 'maven',
-            per_page: 100
-          });
-
-          const repoPackages = packages.filter(pkg => pkg.repository && pkg.repository.name === repo);
-          core.info(`Found ${repoPackages.length} Maven packages linked to ${owner}/${repo}`);
-
-          for (const pkg of repoPackages) {
-            const versions = await github.paginate(
-              'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
-              {
-                org: owner,
-                package_type: 'maven',
-                package_name: pkg.name,
-                per_page: 100
-              }
-            );
-
-            const snapshots = versions
-              .filter(v => (v.name || '').includes('SNAPSHOT'))
-              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
-
-            // Keep the newest 5 snapshot versions and delete older ones.
-            for (const version of snapshots.slice(5)) {
-              core.info(`${dryRun ? '[DRY RUN] Would delete' : 'Deleting'} ${pkg.name}@${version.name} (${version.created_at})`);
-              if (dryRun) {
-                continue;
-              }
-              await github.request(
-                'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
-                {
-                  org: owner,
-                  package_type: 'maven',
-                  package_name: pkg.name,
-                  package_version_id: version.id
-                }
-              );
-            }
-          }
+  release:
+    uses: ./.github/workflows/release-dev-template.yml
+    with:
+      dryRun: ${{ fromJSON(github.event_name == 'schedule' && 'false' || github.event_name == 'workflow_dispatch' && github.event.inputs.dryRun || 'true') }}
+    secrets: inherit

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,4 +1,4 @@
-name: Reusable Dev-Release-Build
+name: Release-Build-Dev
 
 permissions:
   contents: read
@@ -7,6 +7,7 @@ permissions:
 on: 
   schedule:
     - cron:  '21 21 * * *'
+  workflow_dispatch:
   workflow_call:
     inputs:
       javaVersion:
@@ -18,6 +19,9 @@ on:
       mvnArgs:
         type: string
         required: false
+      dryRun:
+        type: boolean
+        default: true
 
 jobs:
   build:
@@ -42,9 +46,19 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        dry_run="${{ github.event_name == 'schedule' && 'false' || inputs.dryRun }}"
+        if [ -z "${dry_run}" ]; then
+          dry_run="true"
+        fi
+
+        goals="release:prepare release:perform"
+        if [ "${dry_run}" = "true" ]; then
+          goals="release:prepare"
+        fi
+
         mvn --batch-mode -Darguments="-Dmaven.test.skip=true\
          -DaltDeploymentRepository=github::https://maven.pkg.github.com/axonivy-market/${{ github.event.repository.name }}"\
-         release:prepare release:perform ${{ inputs.mvnArgs }}
+         ${goals} ${{ inputs.mvnArgs }}
 
   cleanup-snapshots:
     runs-on: ubuntu-latest
@@ -52,10 +66,15 @@ jobs:
     steps:
     - name: Keep last 5 Maven snapshots
       uses: actions/github-script@v7
+      env:
+        DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || inputs.dryRun || 'true' }}
       with:
         script: |
           const owner = context.repo.owner;
           const repo = context.repo.repo;
+          const dryRun = ((process.env.DRY_RUN || 'true').toLowerCase() === 'true');
+
+          core.info(`Dry run: ${dryRun}`);
 
           const packages = await github.paginate('GET /orgs/{org}/packages', {
             org: owner,
@@ -83,7 +102,10 @@ jobs:
 
             // Keep the newest 5 snapshot versions and delete older ones.
             for (const version of snapshots.slice(5)) {
-              core.info(`Deleting ${pkg.name}@${version.name} (${version.created_at})`);
+              core.info(`${dryRun ? '[DRY RUN] Would delete' : 'Deleting'} ${pkg.name}@${version.name} (${version.created_at})`);
+              if (dryRun) {
+                continue;
+              }
               await github.request(
                 'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
                 {

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,5 +1,9 @@
 name: Reusable Dev-Release-Build
 
+permissions:
+  contents: read
+  packages: write
+
 on: 
   schedule:
     - cron:  '21 21 * * *'
@@ -41,3 +45,53 @@ jobs:
         mvn --batch-mode -Darguments="-Dmaven.test.skip=true\
          -DaltDeploymentRepository=github::https://maven.pkg.github.com/axonivy-market/${{ github.event.repository.name }}"\
          release:prepare release:perform ${{ inputs.mvnArgs }}
+
+  cleanup-snapshots:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Keep last 5 Maven snapshots
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+
+          const packages = await github.paginate('GET /orgs/{org}/packages', {
+            org: owner,
+            package_type: 'maven',
+            per_page: 100
+          });
+
+          const repoPackages = packages.filter(pkg => pkg.repository && pkg.repository.name === repo);
+          core.info(`Found ${repoPackages.length} Maven packages linked to ${owner}/${repo}`);
+
+          for (const pkg of repoPackages) {
+            const versions = await github.paginate(
+              'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
+              {
+                org: owner,
+                package_type: 'maven',
+                package_name: pkg.name,
+                per_page: 100
+              }
+            );
+
+            const snapshots = versions
+              .filter(v => (v.name || '').includes('SNAPSHOT'))
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+            // Keep the newest 5 snapshot versions and delete older ones.
+            for (const version of snapshots.slice(5)) {
+              core.info(`Deleting ${pkg.name}@${version.name} (${version.created_at})`);
+              await github.request(
+                'DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}',
+                {
+                  org: owner,
+                  package_type: 'maven',
+                  package_name: pkg.name,
+                  package_version_id: version.id
+                }
+              );
+            }
+          }


### PR DESCRIPTION
Untested (actions are not runnable until they are on master): will address issues when they appear :wink: 

- Flushed old releases by a manual script: we won't provoke Github regretting their free open storage (and some of our packages are pretty large already)
- Never again pre-sales need a running development environment just to try bleeding-edge features.
- We publish 14.0.0-SNAPSHOT releases. Our manual tagged releases b1,2,3,... remain as they are