### PR TITLE
AIAI-452:  EnvironmentNotAvailable when call AgentEditor

### DIFF
--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/output/SensitiveDataOutputGuardrail.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/output/SensitiveDataOutputGuardrail.java
@@ -36,8 +36,6 @@ public class SensitiveDataOutputGuardrail implements SmartWorkflowOutputGuardrai
         "-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----");
   }
 
-  private final Set<String> variables = loadConfiguredApiKeys();
-
   @Override
   public GuardrailResult evaluate(String message) {
     if (message == null || message.isBlank()) {
@@ -51,7 +49,7 @@ public class SensitiveDataOutputGuardrail implements SmartWorkflowOutputGuardrai
   }
 
   private boolean containsConfiguredApiKey(String message) {
-    return variables.stream().anyMatch(message::contains);
+    return loadConfiguredApiKeys().stream().anyMatch(message::contains);
   }
 
   private static Set<String> loadConfiguredApiKeys() {

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/output/SensitiveDataOutputGuardrail.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/output/SensitiveDataOutputGuardrail.java
@@ -36,6 +36,8 @@ public class SensitiveDataOutputGuardrail implements SmartWorkflowOutputGuardrai
         "-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----");
   }
 
+  private Set<String> variables = null;
+
   @Override
   public GuardrailResult evaluate(String message) {
     if (message == null || message.isBlank()) {
@@ -49,7 +51,10 @@ public class SensitiveDataOutputGuardrail implements SmartWorkflowOutputGuardrai
   }
 
   private boolean containsConfiguredApiKey(String message) {
-    return loadConfiguredApiKeys().stream().anyMatch(message::contains);
+    if (variables == null) {
+      variables = loadConfiguredApiKeys();
+    }
+    return variables.stream().anyMatch(message::contains);
   }
 
   private static Set<String> loadConfiguredApiKeys() {


### PR DESCRIPTION
**Problem:**
The Configuration tab cannot be loaded.

<img width="706" height="275" alt="image" src="https://github.com/user-attachments/assets/35a67cc0-77a1-450f-8683-1d29e7a1aa54" />

**Reason:**
During initialization of `SensitiveDataOutputGuardrail`, we call `Ivy.var()` to retrieve secrets. However, the Ivy environment is not accessible within the scope of `AgentEditor`, which causes the failure.

<img width="849" height="394" alt="image" src="https://github.com/user-attachments/assets/aae708a1-b576-4c84-853e-a8321e02ae78" />
