### PR TITLE
refactor: remove CollectionUtils smell :construction:

### DIFF
--- a/models/smart-workflow-azure-openai/src/com/axonivy/utils/smart/workflow/model/azureopenai/internal/utils/VariableUtils.java
+++ b/models/smart-workflow-azure-openai/src/com/axonivy/utils/smart/workflow/model/azureopenai/internal/utils/VariableUtils.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.axonivy.utils.smart.workflow.model.azureopenai.internal.AzureOpenAiConf;
@@ -53,13 +52,9 @@ public final class VariableUtils {
       return null;
     }
 
-    List<AzureAiDeployment> deployments = getDeployments();
-
-    if (CollectionUtils.isEmpty(deployments)) {
-      return null;
-    }
-
-    return deployments.stream().filter(deployment -> deploymentName.equals(deployment.getName())).findFirst()
-        .orElse(null);
+    return getDeployments().stream()
+      .filter(deployment -> deploymentName.equals(deployment.getName()))
+      .findFirst()
+      .orElse(null);
   }
 }

--- a/smart-workflow-demo/src/com/axonivy/utils/smart/workflow/demo/service/IvyAdapterService.java
+++ b/smart-workflow-demo/src/com/axonivy/utils/smart/workflow/demo/service/IvyAdapterService.java
@@ -1,12 +1,11 @@
 package com.axonivy.utils.smart.workflow.demo.service;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-
-import org.apache.commons.collections4.CollectionUtils;
 
 import ch.ivyteam.ivy.process.call.SubProcessCallStartEvent;
 import ch.ivyteam.ivy.process.call.SubProcessSearchFilter;
@@ -28,7 +27,7 @@ public class IvyAdapterService {
    */
 
   public static Map<String, Object> startSubProcessInSecurityContext(String signature, Map<String, Object> params) {
-    return startSubProcess(signature, params, SearchScope.SECURITY_CONTEXT);
+    return startSubProcess(signature, Optional.ofNullable(params).orElse(Map.of()), SearchScope.SECURITY_CONTEXT);
   }
 
   private static Map<String, Object> startSubProcess(String signature, Map<String, Object> params, SearchScope scope) {
@@ -39,18 +38,21 @@ public class IvyAdapterService {
 
       // Find subprocess
       var subProcessStartList = SubProcessCallStartEvent.find(filter);
-      if (CollectionUtils.isEmpty(subProcessStartList)) {
-        return null;
+      if (subProcessStartList.isEmpty()) {
+        return Map.of();
       }
       var subProcessStart = subProcessStartList.get(0);
 
       // Add param to the subprocess and execute
-      return Optional.ofNullable(params).map(Map::entrySet).isEmpty() ? subProcessStart.call().asMap() : startSubProcessWithParams(subProcessStart, params);
+      if (params.isEmpty()) {
+        return subProcessStart.call().asMap();
+      }
+      return startSubProcessWithParams(subProcessStart, params);
     });
   }
 
   private static Map<String, Object> startSubProcessWithParams(SubProcessCallStartEvent subProcess, Map<String, Object> params) {
-    Map<String, Object> result = null;
+    Map<String, Object> result = new HashMap<>();
     List<Entry<String, Object>> entryList = new ArrayList<>(params.entrySet());
 
     for (Entry<String, Object> entry : entryList) {

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/tools/internal/JsonProcessParameters.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/tools/internal/JsonProcessParameters.java
@@ -4,7 +4,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.log4j.Logger;
 
 import com.axonivy.utils.smart.workflow.tools.internal.QualifiedTypeLoader.QType;
@@ -30,7 +29,7 @@ public class JsonProcessParameters {
 
   public Map<String, Object> readParams(List<ToolParameter> parameters, String rawJsonArgs) {
     try {
-      if (CollectionUtils.isEmpty(parameters)) {
+      if (parameters.isEmpty()) {
         return Map.of();
       }
       return toParams(parameters, MAPPER.readTree(rawJsonArgs));

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/tools/internal/JsonToolParamBuilder.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/tools/internal/JsonToolParamBuilder.java
@@ -7,8 +7,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections4.CollectionUtils;
-
 import com.axonivy.utils.smart.workflow.tools.internal.QualifiedTypeLoader.QType;
 import com.axonivy.utils.smart.workflow.tools.provider.SmartWorkflowTool.ToolParameter;
 
@@ -34,7 +32,7 @@ public class JsonToolParamBuilder {
   }
 
   public JsonObjectSchema toParams(List<ToolParameter> parameters) {
-    if (CollectionUtils.isEmpty(parameters)) {
+    if (parameters.isEmpty()) {
       return null; // less tokens + better compliance with Arize Phoenix playground
     }
     var required = new ArrayList<String>();


### PR DESCRIPTION
I think using `CollectionUtils.isEmpty()` is bad practice and should be avoided:
- it implies we have a "null" issue with collections ... while serious code should always guarantee to produce empty collections like "List.of() or Map.of()" instead of returning null.
- extra dependency causes users to think what it does, while X.isEmpty() is clear for everyone.
- if there are actually areas where "null" is returned and its not code under our control ... we should explicitly code it to warn about that uncommon api. 