### PR TITLE
Supply complex project parameters

### DIFF
--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/tools/TestQualifiedTypeLoader.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/tools/TestQualifiedTypeLoader.java
@@ -7,6 +7,7 @@ import java.lang.reflect.ParameterizedType;
 
 import org.junit.jupiter.api.Test;
 
+import com.axonivy.utils.smart.workflow.spi.internal.ProjectClassLoader;
 import com.axonivy.utils.smart.workflow.test.Person;
 import com.axonivy.utils.smart.workflow.tools.internal.QualifiedTypeLoader;
 import com.axonivy.utils.smart.workflow.tools.internal.QualifiedTypeLoader.QType;
@@ -18,36 +19,48 @@ class TestQualifiedTypeLoader {
 
   @Test
   void loadJavaClass() throws Exception {
-    var type = new QualifiedTypeLoader().load(new QType(String.class.getName()));
+    var type = loader().load(new QType(String.class.getName()));
     assertThat(type).isEqualTo(String.class);
   }
 
   @Test
   void loadJavaPrimitive() throws Exception {
-    assertThat(new QualifiedTypeLoader().load(new QType("int"))).isEqualTo(int.class);
-    assertThat(new QualifiedTypeLoader().load(new QType("boolean"))).isEqualTo(boolean.class);
-    assertThat(new QualifiedTypeLoader().load(new QType("double"))).isEqualTo(double.class);
+    assertThat(loader().load(new QType("int"))).isEqualTo(int.class);
+    assertThat(loader().load(new QType("boolean"))).isEqualTo(boolean.class);
+    assertThat(loader().load(new QType("double"))).isEqualTo(double.class);
   }
 
   @Test
   void loadList() throws Exception {
-    var type = new QualifiedTypeLoader().load(new QType("java.util.List<java.lang.String>"));
+    var type = loader().load(new QType("java.util.List<java.lang.String>"));
     assertThat(type).isInstanceOf(ParameterizedType.class);
     assertThat(type.getTypeName()).isEqualTo("java.util.List<java.lang.String>");
   }
 
   @Test
-  void loadWithExternalClassLoader() throws Exception {
+  void loadWithExternalClassLoader_explicit() throws Exception {
     var cl = Person.class.getClassLoader();
     var type = new QualifiedTypeLoader(cl).load(new QType(Person.class.getName()));
     assertThat(type).isEqualTo(Person.class);
   }
 
   @Test
+  void loadWithExternalClassLoader_pmvContext() throws Exception {
+    var cl =  ProjectClassLoader.current();
+    var type = new QualifiedTypeLoader(cl).load(new QType(Person.class.getName()));
+    assertThat(type).isEqualTo(Person.class);
+  }
+
+  @Test
   void loadIncorrectType() throws Exception {
-    assertThat(new QualifiedTypeLoader().load(null)).isNull();
-    assertThat(new QualifiedTypeLoader().load(new QType(""))).isNull();
-    assertThatThrownBy(() -> new QualifiedTypeLoader().load(new QType("com.example.DoesNotExist")))
+    assertThat(loader().load(null)).isNull();
+    assertThat(loader().load(new QType(""))).isNull();
+    assertThatThrownBy(() -> loader().load(new QType("com.example.DoesNotExist")))
         .isInstanceOf(ClassNotFoundException.class);
   }
+
+  private static QualifiedTypeLoader loader() {
+    return new QualifiedTypeLoader(ProjectClassLoader.current());
+  }
+
 }

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/ProjectClassLoader.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/ProjectClassLoader.java
@@ -1,0 +1,28 @@
+package com.axonivy.utils.smart.workflow.spi.internal;
+
+import org.apache.commons.lang3.reflect.MethodUtils;
+
+import ch.ivyteam.ivy.application.IProcessModelVersion;
+import ch.ivyteam.ivy.project.model.Project;
+
+public class ProjectClassLoader {
+
+  private static final String JAVA_RUNTIME = "ch.ivyteam.ivy.java.JavaRuntime";
+
+  public static ClassLoader current() {
+    return of(IProcessModelVersion.current().project());
+  }
+
+  public static ClassLoader of(Project project) {
+    try {
+      var javaConf = Class.forName(JAVA_RUNTIME);
+      var of = MethodUtils.getMethodObject(javaConf, "of", Project.class);
+      var local = of.invoke(null, project);
+      var loader = MethodUtils.getMethodObject(javaConf, "getClassLoader");
+      return (ClassLoader) loader.invoke(local);
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+}

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiLoader.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiLoader.java
@@ -12,15 +12,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.reflect.MethodUtils;
-
 import ch.ivyteam.ivy.application.IProcessModelVersion;
 import ch.ivyteam.ivy.project.model.Project;
 
 public class SpiLoader {
   private final Project project;
 
-  private static final String JAVA_RUNTIME = "ch.ivyteam.ivy.java.JavaRuntime";
   private static final String SERVICES_LOCATION_PATTERN = "META-INF/services/%s";
   private static final String EXCEPTION_PATTERN = "Failed to read service descriptor %s";
 
@@ -43,7 +40,7 @@ public class SpiLoader {
   }
 
   private static <T> List<T> findImpl(Project project, Class<T> type) {
-    ClassLoader loader = loaderOf(project);
+    ClassLoader loader = ProjectClassLoader.of(project);
     return findImpl(type, loader);
   }
 
@@ -55,20 +52,7 @@ public class SpiLoader {
     return implNames.stream().flatMap(ref -> {
       Optional<T> impl = load(loader, ref);
       return impl.stream();
-    })
-        .toList();
-  }
-
-  private static ClassLoader loaderOf(Project project) {
-    try {
-      var javaConf = Class.forName(JAVA_RUNTIME);
-      var of = MethodUtils.getMethodObject(javaConf, "of", Project.class);
-      var local = of.invoke(null, project);
-      var loader = MethodUtils.getMethodObject(javaConf, "getClassLoader");
-      return (ClassLoader) loader.invoke(local);
-    } catch (Exception ex) {
-      throw new RuntimeException(ex);
-    }
+    }).toList();
   }
 
   private static <T> Optional<T> load(ClassLoader loader, String typeName) {

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/tools/internal/JsonProcessParameters.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/tools/internal/JsonProcessParameters.java
@@ -6,11 +6,14 @@ import java.util.Map;
 
 import org.apache.log4j.Logger;
 
+import com.axonivy.utils.smart.workflow.spi.internal.ProjectClassLoader;
 import com.axonivy.utils.smart.workflow.tools.internal.QualifiedTypeLoader.QType;
 import com.axonivy.utils.smart.workflow.tools.provider.SmartWorkflowTool.ToolParameter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ch.ivyteam.api.API;
 
 public class JsonProcessParameters {
 
@@ -20,10 +23,11 @@ public class JsonProcessParameters {
   private final ClassLoader classLoader;
 
   public JsonProcessParameters() {
-    this(null);
+    this(ProjectClassLoader.current());
   }
 
   public JsonProcessParameters(ClassLoader classLoader) {
+    API.checkParameterNotNull(classLoader, "classLoader");
     this.classLoader = classLoader;
   }
 

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/tools/internal/JsonToolParamBuilder.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/tools/internal/JsonToolParamBuilder.java
@@ -7,9 +7,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.axonivy.utils.smart.workflow.spi.internal.ProjectClassLoader;
 import com.axonivy.utils.smart.workflow.tools.internal.QualifiedTypeLoader.QType;
 import com.axonivy.utils.smart.workflow.tools.provider.SmartWorkflowTool.ToolParameter;
 
+import ch.ivyteam.api.API;
 import ch.ivyteam.log.Logger;
 import dev.langchain4j.internal.JsonSchemaElementUtils;
 import dev.langchain4j.internal.JsonSchemaElementUtils.VisitedClassMetadata;
@@ -24,10 +26,11 @@ public class JsonToolParamBuilder {
   private final JsonObjectSchema.Builder builder = JsonObjectSchema.builder();
 
   public JsonToolParamBuilder() {
-    this(null);
+    this(ProjectClassLoader.current());
   }
 
   public JsonToolParamBuilder(ClassLoader classLoader) {
+    API.checkParameterNotNull(classLoader, "classLoader");
     this.classLoader = classLoader;
   }
 

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/tools/internal/QualifiedTypeLoader.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/tools/internal/QualifiedTypeLoader.java
@@ -9,6 +9,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.google.inject.util.Types;
 
+import ch.ivyteam.api.API;
+
 /**
  * Forked from ivy-core internals.
  * If this is useful somewhere else, leave me a note
@@ -28,11 +30,8 @@ public class QualifiedTypeLoader {
 
   private final ClassLoader classLoader;
 
-  public QualifiedTypeLoader() {
-    this(null);
-  }
-
   public QualifiedTypeLoader(ClassLoader classLoader) {
+    API.checkParameterNotNull(classLoader, "classLoader");
     this.classLoader = classLoader;
   }
 
@@ -95,9 +94,7 @@ public class QualifiedTypeLoader {
     if (primitive != null) {
       return primitive;
     }
-    return classLoader != null ?
-        Class.forName(type.rawType(), true, classLoader) :
-        Class.forName(type.rawType());
+    return Class.forName(type.rawType(), true, classLoader);
   }
 
   private Type[] loadParameters(QType qType) throws ClassNotFoundException {


### PR DESCRIPTION
there is/was indeed a bug; that prevents complex parameters to be loaded. 
Cause is the unknown classloader, we always need to load with the classloader from the calling project ... in order to see all classes available to sub-processes (which may live in this calling or an intermediate project).

- [x] harden the test cases: currently the only place where complex param loading works is in test :blush: 

```
[2026-04-17 17:33:00.498][ERROR][com.axonivy.utils.smart.workflow.tools.internal.JsonToolParamBuilder][ivy background operation pool-thread-1]{application=Developer-smart-workflow, client=0:0:0:0:0:0:0:1, executionContext=3 Developer, pmv=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow-test, processElement=19D9B40B0E198091-f3, request=HTTP GET hibernate/Hibernation.p.json/ask.ivp(1.1.0.0), requestId=23, securityContext=~Developer-smart-workflow, session=3 Developer, task=1}
Failed to define json parameter for tool parameter ToolParameter[name=decision, description=required: the decision which should be done by the human user, type=hibernate.HumanDecision]
java.lang.ClassNotFoundException: hibernate.HumanDecision
	at ch.ivyteam.ivy.java.internal.IvyProjectClassLoader.handleClassNotFoundCase(IvyProjectClassLoader.java:278)
	at ch.ivyteam.ivy.java.internal.IvyProjectClassLoader.lambda$3(IvyProjectClassLoader.java:188)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at ch.ivyteam.ivy.java.internal.IvyProjectClassLoader.findClass(IvyProjectClassLoader.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:557)
	at ch.ivyteam.ivy.java.internal.IvyProjectClassLoader.loadClass(IvyProjectClassLoader.java:174)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:467)
	at java.base/java.lang.Class.forName(Class.java:458)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//com.axonivy.utils.smart.workflow.tools.internal.QualifiedTypeLoader.loadRaw(QualifiedTypeLoader.java:100)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//com.axonivy.utils.smart.workflow.tools.internal.QualifiedTypeLoader.load(QualifiedTypeLoader.java:84)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//com.axonivy.utils.smart.workflow.tools.internal.JsonToolParamBuilder.toJsonParam(JsonToolParamBuilder.java:52)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//com.axonivy.utils.smart.workflow.tools.internal.JsonToolParamBuilder.lambda$0(JsonToolParamBuilder.java:43)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//com.axonivy.utils.smart.workflow.tools.internal.JsonToolParamBuilder.toParams(JsonToolParamBuilder.java:42)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//com.axonivy.utils.smart.workflow.tools.internal.IvySubProcessToolSpecs.toTool(IvySubProcessToolSpecs.java:32)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:214)
	at java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:722)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:153)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:176)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:632)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//com.axonivy.utils.smart.workflow.tools.provider.IvySubProcessToolsProvider.provideTools(IvySubProcessToolsProvider.java:33)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//com.axonivy.utils.smart.workflow.program.internal.AgentCallExecutor.lambda$7(AgentCallExecutor.java:138)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//dev.langchain4j.service.tool.ToolService.lambda$createContextFromStaticToolsAndProviders$0(ToolService.java:301)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//dev.langchain4j.service.tool.ToolService.createContextFromStaticToolsAndProviders(ToolService.java:296)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//dev.langchain4j.service.tool.ToolService.createContext(ToolService.java:262)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//dev.langchain4j.service.DefaultAiServices$1.invoke(DefaultAiServices.java:261)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//dev.langchain4j.service.DefaultAiServices$1.invoke(DefaultAiServices.java:155)
	at jdk.proxy45/jdk.proxy45.$Proxy227.chat(Unknown Source)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//com.axonivy.utils.smart.workflow.program.internal.AgentCallExecutor.execute(AgentCallExecutor.java:75)
	at IvyProjectClassLoader [project=~Developer-smart-workflow/Developer-smart-workflow/1/smart-workflow,generation=1]//com.axonivy.utils.smart.workflow.AgenticProcessCall.lambda$0(AgenticProcessCall.java:18)
	at ch.ivyteam.ivy.bpm.exec.internal.activity.program.executor.ProgramExecBeanHolder.lambda$1(ProgramExecBeanHolder.java:69)
	at ch.ivyteam.util.context.IExecutionContext.lambda$0(IExecutionContext.java:15)
	at ch.ivyteam.util.context.AbstractExecutionContext.callInContext(AbstractExecutionContext.java:11)
	at ch.ivyteam.util.context.IExecutionContext.executeInContext(IExecutionContext.java:14)
	at ch.ivyteam.ivy.bpm.exec.internal.activity.program.executor.ProgramExecBeanHolder.run(ProgramExecBeanHolder.java:66)
	at ch.ivyteam.ivy.bpm.exec.internal.activity.program.executor.ProgramBackgroundOperation.execute(ProgramBackgroundOperation.java:26)
	at ch.ivyteam.ivy.bpm.exec.internal.activity.program.executor.ProgramBackgroundOperation.execute(ProgramBackgroundOperation.java:1)
	at ch.ivyteam.ivy.bpm.engine.internal.background.wrapper.BackgroundOperationWrapper.execute(BackgroundOperationWrapper.java:21)
	at ch.ivyteam.ivy.bpm.engine.internal.background.wrapper.ExecuteBackgroundOperationAsSessionUserWrapper.access$0(ExecuteBackgroundOperationAsSessionUserWrapper.java:1)
	at ch.ivyteam.util.context.AbstractExecutionContext.callInContext(AbstractExecutionContext.java:11)
	at ch.ivyteam.ivy.security.internal.context.SecurityContext.executeAs(SecurityContext.java:218)
	at ch.ivyteam.ivy.bpm.engine.internal.background.wrapper.ExecuteBackgroundOperationAsSessionUserWrapper.execute(ExecuteBackgroundOperationAsSessionUserWrapper.java:29)
	at ch.ivyteam.ivy.bpm.engine.internal.background.wrapper.BackgroundOperationWrapper.execute(BackgroundOperationWrapper.java:21)
	at ch.ivyteam.ivy.bpm.engine.internal.background.wrapper.ExecuteBackgroundOperationInRequestThreadContextWrapper.execute(ExecuteBackgroundOperationInRequestThreadContextWrapper.java:22)
	at ch.ivyteam.ivy.bpm.engine.internal.background.BackgroundTask.call(BackgroundTask.java:37)
	at ch.ivyteam.ivy.bpm.engine.internal.background.BackgroundTask.call(BackgroundTask.java:1)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
```