### PR TITLE
Identify smart-workflow PMV by LibraryID

### DIFF
--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiProject.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiProject.java
@@ -5,15 +5,23 @@ import java.util.function.Predicate;
 import ch.ivyteam.ivy.application.IProcessModelVersion;
 
 public final class SpiProject {
-  static String SMART_WORKFLOW_PROJECT = "smart-workflow";
+
+  private interface SmartWorkflow {
+    String GROUP_ID = "com.axonivy.utils.ai";
+    String ARTIFACT_ID = "smart-workflow";
+    String LIBRARY_ID = GROUP_ID + ":" + ARTIFACT_ID;
+  }
 
   public static IProcessModelVersion getSmartWorkflowPmv() {
-    Predicate<IProcessModelVersion> smartWorkflow = pmv -> SMART_WORKFLOW_PROJECT.equals(pmv.getName());
+    Predicate<IProcessModelVersion> smartWorkflow = pmv -> 
+      SmartWorkflow.LIBRARY_ID.equals(pmv.getLibraryId());
     var current = IProcessModelVersion.current();
     if (smartWorkflow.test(current)) {
       return current;
     }
     return current.getAllRequiredProcessModelVersions()
-        .filter(smartWorkflow).findAny().orElseThrow();
+        .filter(smartWorkflow)
+        .findAny()
+        .orElseThrow();
   }
 }

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiProject.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiProject.java
@@ -20,8 +20,12 @@ public final class SpiProject {
       return current;
     }
     return current.getAllRequiredProcessModelVersions()
+        .toList().stream()
         .filter(smartWorkflow)
         .findAny()
-        .orElseThrow();
+        .orElseThrow(() -> new IllegalStateException(String.format(
+            "Cannot resolve Smart Workflow PMV. Expected libraryId='%s', currentLibraryId='%s'",
+            SmartWorkflow.LIBRARY_ID,
+            current.getLibraryId())));
   }
 }


### PR DESCRIPTION
Use the deterministic LibraryId (groupId+artifactId) from pom.xml to identify smart-workflow. Fixes #249 