### PR TITLE
XIVY-18649 Serializer for ChatMessages :mailbox_with_mail: 

### DIFF
--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/memory/store/TestMessageSerializer.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/memory/store/TestMessageSerializer.java
@@ -11,17 +11,17 @@ import ch.ivyteam.ivy.environment.IvyTest;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.AudioContent;
-import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ChatMessageDeserializer;
+import dev.langchain4j.data.message.ChatMessageSerializer;
 import dev.langchain4j.data.message.CustomMessage;
 import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.ImageContent.DetailLevel;
 import dev.langchain4j.data.message.PdfFileContent;
 import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.ToolExecutionResultMessage;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.data.message.VideoContent;
-import dev.langchain4j.data.message.ImageContent.DetailLevel;
 
 @IvyTest
 class TestMessageSerializer {
@@ -53,7 +53,7 @@ class TestMessageSerializer {
   void readWrite_system() {
     var system = new SystemMessage("systematic");
     var json = MessageSerializer.write(List.of(system));
-    assertThat(json).isEqualTo("{\"messages\":[{\"type\":\"SystemMessage\",\"text\":\"systematic\"}]}");
+    assertThat(json).isEqualTo("[{\"text\":\"systematic\",\"type\":\"SYSTEM\"}]");
 
     var messages = MessageSerializer.read(json);
     assertThat(messages).hasSize(1);
@@ -64,41 +64,22 @@ class TestMessageSerializer {
   @Test
   void readWrite_userOnly() throws Exception {
     var user = new UserMessage(List.of(new TextContent("hey there")));
-    var json = MessageSerializer.MAPPER.valueToTree(user);
+    var json = ChatMessageSerializer.messageToJson(user);
 
 
-    assertThat(json.toString()).isEqualTo("{\"type\":\"UserMessage\",\"contents\":[{\"type\":\"TextContent\",\"text\":\"hey there\"}],\"attributes\":{}}");
+    assertThat(json.toString()).isEqualTo("{\"contents\":[{\"text\":\"hey there\",\"type\":\"TEXT\"}],\"type\":\"USER\"}");
 
-    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), UserMessage.class);
+    var reloaded = ChatMessageDeserializer.messageFromJson(json.toString());
     assertThat(reloaded).isEqualTo(user);
-  }
-
-
-  @Test
-  void readWrite_userWrapped() throws Exception {
-    var user = new UserMessage(List.of(new TextContent("hey there")));
-    var wrapper = new MessageWrapper();
-    wrapper.message = user;
-    var json = MessageSerializer.MAPPER.valueToTree(wrapper);
-
-    assertThat(json.toString())
-        .isEqualTo("{\"message\":{\"type\":\"UserMessage\",\"contents\":[{\"type\":\"TextContent\",\"text\":\"hey there\"}],\"attributes\":{}}}");
-
-    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), MessageWrapper.class);
-    assertThat(reloaded.message).isEqualTo(user);
-  }
-
-  private static class MessageWrapper {
-    public ChatMessage message;
   }
   
   @Test
   void readWrite_systemOnly() throws Exception {
     var system = new SystemMessage("systematic");
-    var json = MessageSerializer.MAPPER.valueToTree(system);
-    assertThat(json.toString()).isEqualTo("{\"type\":\"SystemMessage\",\"text\":\"systematic\"}");
+    var json = ChatMessageSerializer.messageToJson(system);
+    assertThat(json.toString()).isEqualTo("{\"text\":\"systematic\",\"type\":\"SYSTEM\"}");
 
-    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), SystemMessage.class);
+    var reloaded = ChatMessageDeserializer.messageFromJson(json.toString());
     assertThat(reloaded).isEqualTo(system);
   }
 
@@ -110,23 +91,22 @@ class TestMessageSerializer {
       .arguments("add(1,2)")
       .build();
     var ai = new AiMessage("artificial intelligence", List.of(add));
-    var json = MessageSerializer.MAPPER.valueToTree(ai);
+    var json = ChatMessageSerializer.messageToJson(ai);
     assertThat(json.toString())
-      .isEqualTo("{\"type\":\"AiMessage\",\"text\":\"artificial intelligence\","+
-      "\"toolExecutionRequests\":[{\"id\":\"id123\",\"name\":\"add\",\"arguments\":\"add(1,2)\"}],\"attributes\":{}}");
+      .isEqualTo("{\"text\":\"artificial intelligence\",\"toolExecutionRequests\":[{\"id\":\"id123\",\"name\":\"add\",\"arguments\":\"add(1,2)\"}],\"attributes\":{},\"type\":\"AI\"}");
 
-    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), AiMessage.class);
+    var reloaded = ChatMessageDeserializer.messageFromJson(json.toString());
     assertThat(reloaded).isEqualTo(ai);
   }
 
   @Test
   void readWrite_customOnly() throws Exception {
     var custom = new CustomMessage(Map.of("a","b"));
-    var json = MessageSerializer.MAPPER.valueToTree(custom);
+    var json = ChatMessageSerializer.messageToJson(custom);
     assertThat(json.toString())
-        .isEqualTo("{\"type\":\"CustomMessage\",\"attributes\":{\"a\":\"b\"}}");
+        .isEqualTo("{\"attributes\":{\"a\":\"b\"},\"type\":\"CUSTOM\"}");
 
-    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), CustomMessage.class);
+    var reloaded = ChatMessageDeserializer.messageFromJson(json.toString());
     assertThat(reloaded).isEqualTo(custom);
   }
 
@@ -136,92 +116,11 @@ class TestMessageSerializer {
       .id("id123")
       .contents(List.of(new TextContent("the result")))
       .build();
-    var json = MessageSerializer.MAPPER.valueToTree(toolResponse);
+    var json = ChatMessageSerializer.messageToJson(toolResponse);
     assertThat(json.toString())
-        .isEqualTo("{\"type\":\"ToolExecutionResultMessage\",\"id\":\"id123\",\"contents\":[{\"type\":\"TextContent\",\"text\":\"the result\"}],\"attributes\":{}}");
+        .isEqualTo("{\"id\":\"id123\",\"contents\":[{\"text\":\"the result\",\"type\":\"TEXT\"}],\"attributes\":{},\"type\":\"TOOL_EXECUTION_RESULT\"}");
 
-    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), ToolExecutionResultMessage.class);
+    var reloaded = ChatMessageDeserializer.messageFromJson(json.toString());
     assertThat(reloaded).isEqualTo(toolResponse);
-  }
-
-  @Test
-  void readWrite_textContentOnly() throws Exception {
-    var textContent = new TextContent("systematic");
-    var json = MessageSerializer.MAPPER.valueToTree(textContent);
-    assertThat(json.toString()).isEqualTo("{\"type\":\"TextContent\",\"text\":\"systematic\"}");
-
-    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), TextContent.class);
-    assertThat(reloaded).isEqualTo(textContent);
-  }
-
-  @Test
-  void readWrite_textContentAnonymous() throws Exception {
-    var textContent = (Content)new TextContent("systematic");
-    var json = MessageSerializer.MAPPER.valueToTree(textContent);
-    assertThat(json.toString()).isEqualTo("{\"type\":\"TextContent\",\"text\":\"systematic\"}");
-
-    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), Content.class);
-    assertThat(reloaded).isEqualTo(textContent);
-  }
-
-  @Test
-  void readWrite_textContentAnonymousWrapped() throws Exception {
-    var wrapper = new ContentWrapper();
-    wrapper.content = new TextContent("systematic");
-    var json = MessageSerializer.MAPPER.valueToTree(wrapper);
-    assertThat(json.toString()).isEqualTo("{\"content\":{\"type\":\"TextContent\",\"text\":\"systematic\"}}");
-
-    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), ContentWrapper.class);
-    assertThat(reloaded.content).isEqualTo(wrapper.content);
-  }
-
-  private static class ContentWrapper {
-    public Content content;
-  }
-
-  @Test
-  void readWrite_imageContentOnly() throws Exception {
-    var imageContent = new ImageContent("file://path/to/image.jpg", DetailLevel.LOW);
-    var json = MessageSerializer.MAPPER.valueToTree(imageContent);
-    assertThat(json.toString()).isEqualTo("{\"type\":\"ImageContent\","+
-      "\"image\":{\"url\":\"file://path/to/image.jpg\",\"base64Data\":null,\"mimeType\":null,\"revisedPrompt\":null},"+
-      "\"detailLevel\":\"LOW\"}");
-
-    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), ImageContent.class);
-    assertThat(reloaded).isEqualTo(imageContent);
-  }
-
-
-  @Test
-  void readWrite_audioContentOnly() throws Exception {
-    var audioContent = new AudioContent("file://path/to/audio.mp3");
-    var json = MessageSerializer.MAPPER.valueToTree(audioContent);
-    assertThat(json.toString()).isEqualTo("{\"type\":\"AudioContent\","+
-      "\"audio\":{\"url\":\"file://path/to/audio.mp3\",\"binaryData\":null,\"base64Data\":null,\"mimeType\":null}}");
-
-    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), AudioContent.class);
-    assertThat(reloaded).isEqualTo(audioContent);
-  }
-
-  @Test
-  void readWrite_pdfContentOnly() throws Exception {
-    var pdfContent = new PdfFileContent("file://path/to/doc.pdf");
-    var json = MessageSerializer.MAPPER.valueToTree(pdfContent);
-    assertThat(json.toString()).isEqualTo("{\"type\":\"PdfFileContent\"," +
-        "\"pdfFile\":{\"url\":\"file://path/to/doc.pdf\",\"base64Data\":null,\"mimeType\":\"application/pdf\"}}");
-
-    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), PdfFileContent.class);
-    assertThat(reloaded).isEqualTo(pdfContent);
-  }
-
-  @Test
-  void readWrite_videoContentOnly() throws Exception {
-    var videoContent = new VideoContent("file://path/to/video.mp4");
-    var json = MessageSerializer.MAPPER.valueToTree(videoContent);
-    assertThat(json.toString()).isEqualTo("{\"type\":\"VideoContent\"," +
-        "\"video\":{\"url\":\"file://path/to/video.mp4\",\"base64Data\":null,\"mimeType\":null}}");
-
-    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), VideoContent.class);
-    assertThat(reloaded).isEqualTo(videoContent);
   }
 }

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/memory/store/TestMessageSerializer.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/memory/store/TestMessageSerializer.java
@@ -1,0 +1,227 @@
+package com.axonivy.utils.smart.workflow.memory.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import ch.ivyteam.ivy.environment.IvyTest;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.AudioContent;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.CustomMessage;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.PdfFileContent;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.message.VideoContent;
+import dev.langchain4j.data.message.ImageContent.DetailLevel;
+
+@IvyTest
+class TestMessageSerializer {
+
+  @Test
+  void readWrite_allContents() {
+    var user = new UserMessage(List.of(
+      new TextContent("hey there"),
+      new ImageContent("file://path/to/image.jpg", DetailLevel.LOW),
+      new AudioContent("file://path/to/audio.mp3"),
+      new PdfFileContent("file://path/to/doc.pdf"),
+      new VideoContent("file://path/to/video.mp4")
+    ));
+    var json = MessageSerializer.write(List.of(user));
+    assertThat(json)
+      .contains("hey there")
+      .contains("image.jpg")
+      .contains("audio.mp3")
+      .contains("doc.pdf")
+      .contains("video.mp4");
+
+    var messages = MessageSerializer.read(json);
+    assertThat(messages).hasSize(1);
+    var msg = messages.get(0);
+    assertThat((UserMessage)msg).isEqualTo(user); 
+  }
+
+  @Test
+  void readWrite_system() {
+    var system = new SystemMessage("systematic");
+    var json = MessageSerializer.write(List.of(system));
+    assertThat(json).isEqualTo("{\"messages\":[{\"type\":\"SystemMessage\",\"text\":\"systematic\"}]}");
+
+    var messages = MessageSerializer.read(json);
+    assertThat(messages).hasSize(1);
+    var msg = messages.get(0);
+    assertThat((SystemMessage) msg).isEqualTo(system);
+  }
+
+  @Test
+  void readWrite_userOnly() throws Exception {
+    var user = new UserMessage(List.of(new TextContent("hey there")));
+    var json = MessageSerializer.MAPPER.valueToTree(user);
+
+
+    assertThat(json.toString()).isEqualTo("{\"type\":\"UserMessage\",\"contents\":[{\"type\":\"TextContent\",\"text\":\"hey there\"}],\"attributes\":{}}");
+
+    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), UserMessage.class);
+    assertThat(reloaded).isEqualTo(user);
+  }
+
+
+  @Test
+  void readWrite_userWrapped() throws Exception {
+    var user = new UserMessage(List.of(new TextContent("hey there")));
+    var wrapper = new MessageWrapper();
+    wrapper.message = user;
+    var json = MessageSerializer.MAPPER.valueToTree(wrapper);
+
+    assertThat(json.toString())
+        .isEqualTo("{\"message\":{\"type\":\"UserMessage\",\"contents\":[{\"type\":\"TextContent\",\"text\":\"hey there\"}],\"attributes\":{}}}");
+
+    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), MessageWrapper.class);
+    assertThat(reloaded.message).isEqualTo(user);
+  }
+
+  private static class MessageWrapper {
+    public ChatMessage message;
+  }
+  
+  @Test
+  void readWrite_systemOnly() throws Exception {
+    var system = new SystemMessage("systematic");
+    var json = MessageSerializer.MAPPER.valueToTree(system);
+    assertThat(json.toString()).isEqualTo("{\"type\":\"SystemMessage\",\"text\":\"systematic\"}");
+
+    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), SystemMessage.class);
+    assertThat(reloaded).isEqualTo(system);
+  }
+
+  @Test
+  void readWrite_aiOnly() throws Exception {
+    var add = ToolExecutionRequest.builder()
+      .id("id123")
+      .name("add")
+      .arguments("add(1,2)")
+      .build();
+    var ai = new AiMessage("artificial intelligence", List.of(add));
+    var json = MessageSerializer.MAPPER.valueToTree(ai);
+    assertThat(json.toString())
+      .isEqualTo("{\"type\":\"AiMessage\",\"text\":\"artificial intelligence\","+
+      "\"toolExecutionRequests\":[{\"id\":\"id123\",\"name\":\"add\",\"arguments\":\"add(1,2)\"}],\"attributes\":{}}");
+
+    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), AiMessage.class);
+    assertThat(reloaded).isEqualTo(ai);
+  }
+
+  @Test
+  void readWrite_customOnly() throws Exception {
+    var custom = new CustomMessage(Map.of("a","b"));
+    var json = MessageSerializer.MAPPER.valueToTree(custom);
+    assertThat(json.toString())
+        .isEqualTo("{\"type\":\"CustomMessage\",\"attributes\":{\"a\":\"b\"}}");
+
+    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), CustomMessage.class);
+    assertThat(reloaded).isEqualTo(custom);
+  }
+
+  @Test
+  void readWrite_toolResponseOnly() throws Exception {
+    var toolResponse = ToolExecutionResultMessage.builder()
+      .id("id123")
+      .contents(List.of(new TextContent("the result")))
+      .build();
+    var json = MessageSerializer.MAPPER.valueToTree(toolResponse);
+    assertThat(json.toString())
+        .isEqualTo("{\"type\":\"ToolExecutionResultMessage\",\"id\":\"id123\",\"contents\":[{\"type\":\"TextContent\",\"text\":\"the result\"}],\"attributes\":{}}");
+
+    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), ToolExecutionResultMessage.class);
+    assertThat(reloaded).isEqualTo(toolResponse);
+  }
+
+  @Test
+  void readWrite_textContentOnly() throws Exception {
+    var textContent = new TextContent("systematic");
+    var json = MessageSerializer.MAPPER.valueToTree(textContent);
+    assertThat(json.toString()).isEqualTo("{\"type\":\"TextContent\",\"text\":\"systematic\"}");
+
+    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), TextContent.class);
+    assertThat(reloaded).isEqualTo(textContent);
+  }
+
+  @Test
+  void readWrite_textContentAnonymous() throws Exception {
+    var textContent = (Content)new TextContent("systematic");
+    var json = MessageSerializer.MAPPER.valueToTree(textContent);
+    assertThat(json.toString()).isEqualTo("{\"type\":\"TextContent\",\"text\":\"systematic\"}");
+
+    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), Content.class);
+    assertThat(reloaded).isEqualTo(textContent);
+  }
+
+  @Test
+  void readWrite_textContentAnonymousWrapped() throws Exception {
+    var wrapper = new ContentWrapper();
+    wrapper.content = new TextContent("systematic");
+    var json = MessageSerializer.MAPPER.valueToTree(wrapper);
+    assertThat(json.toString()).isEqualTo("{\"content\":{\"type\":\"TextContent\",\"text\":\"systematic\"}}");
+
+    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), ContentWrapper.class);
+    assertThat(reloaded.content).isEqualTo(wrapper.content);
+  }
+
+  private static class ContentWrapper {
+    public Content content;
+  }
+
+  @Test
+  void readWrite_imageContentOnly() throws Exception {
+    var imageContent = new ImageContent("file://path/to/image.jpg", DetailLevel.LOW);
+    var json = MessageSerializer.MAPPER.valueToTree(imageContent);
+    assertThat(json.toString()).isEqualTo("{\"type\":\"ImageContent\","+
+      "\"image\":{\"url\":\"file://path/to/image.jpg\",\"base64Data\":null,\"mimeType\":null,\"revisedPrompt\":null},"+
+      "\"detailLevel\":\"LOW\"}");
+
+    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), ImageContent.class);
+    assertThat(reloaded).isEqualTo(imageContent);
+  }
+
+
+  @Test
+  void readWrite_audioContentOnly() throws Exception {
+    var audioContent = new AudioContent("file://path/to/audio.mp3");
+    var json = MessageSerializer.MAPPER.valueToTree(audioContent);
+    assertThat(json.toString()).isEqualTo("{\"type\":\"AudioContent\","+
+      "\"audio\":{\"url\":\"file://path/to/audio.mp3\",\"binaryData\":null,\"base64Data\":null,\"mimeType\":null}}");
+
+    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), AudioContent.class);
+    assertThat(reloaded).isEqualTo(audioContent);
+  }
+
+  @Test
+  void readWrite_pdfContentOnly() throws Exception {
+    var pdfContent = new PdfFileContent("file://path/to/doc.pdf");
+    var json = MessageSerializer.MAPPER.valueToTree(pdfContent);
+    assertThat(json.toString()).isEqualTo("{\"type\":\"PdfFileContent\"," +
+        "\"pdfFile\":{\"url\":\"file://path/to/doc.pdf\",\"base64Data\":null,\"mimeType\":\"application/pdf\"}}");
+
+    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), PdfFileContent.class);
+    assertThat(reloaded).isEqualTo(pdfContent);
+  }
+
+  @Test
+  void readWrite_videoContentOnly() throws Exception {
+    var videoContent = new VideoContent("file://path/to/video.mp4");
+    var json = MessageSerializer.MAPPER.valueToTree(videoContent);
+    assertThat(json.toString()).isEqualTo("{\"type\":\"VideoContent\"," +
+        "\"video\":{\"url\":\"file://path/to/video.mp4\",\"base64Data\":null,\"mimeType\":null}}");
+
+    var reloaded = MessageSerializer.MAPPER.readValue(json.toString(), VideoContent.class);
+    assertThat(reloaded).isEqualTo(videoContent);
+  }
+}

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/memory/store/MessageSerializer.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/memory/store/MessageSerializer.java
@@ -1,0 +1,235 @@
+package com.axonivy.utils.smart.workflow.memory.store;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.audio.Audio;
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.AudioContent;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.CustomMessage;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.ImageContent.DetailLevel;
+import dev.langchain4j.data.message.PdfFileContent;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.message.VideoContent;
+import dev.langchain4j.data.pdf.PdfFile;
+import dev.langchain4j.data.video.Video;
+
+public class MessageSerializer {
+
+  static final ObjectMapper MAPPER = createMapper();
+
+  public static List<ChatMessage> read(String json) {
+    try {
+      return MAPPER.readValue(json, Messages.class).messages;
+    } catch (Exception ex) {
+      throw new RuntimeException("Failed to deserialize messages", ex);
+    }
+  }
+
+  public static String write(List<ChatMessage> messages) {
+    try {
+      Messages msgs = new Messages(messages);
+      return MAPPER.writeValueAsString(msgs);
+    } catch (Exception ex) {
+      throw new RuntimeException("Failed to serialize messages", ex);
+    }
+  }
+
+  private static ObjectMapper createMapper() {
+    var mapper = new ObjectMapper();
+    mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.registerSubtypes(
+        new NamedType(UserMessage.class, UserMessage.class.getSimpleName()),
+        new NamedType(SystemMessage.class, SystemMessage.class.getSimpleName()),
+        new NamedType(AiMessage.class, AiMessage.class.getSimpleName()),
+        new NamedType(ToolExecutionResultMessage.class, ToolExecutionResultMessage.class.getSimpleName()),
+        new NamedType(CustomMessage.class, CustomMessage.class.getSimpleName()),
+
+        new NamedType(TextContent.class, TextContent.class.getSimpleName()),
+        new NamedType(ImageContent.class, ImageContent.class.getSimpleName()),
+        new NamedType(AudioContent.class, AudioContent.class.getSimpleName()),
+        new NamedType(PdfFileContent.class, PdfFileContent.class.getSimpleName()),
+        new NamedType(VideoContent.class, VideoContent.class.getSimpleName()));
+
+    mapper.addMixIn(ChatMessage.class, MessageMixIn.class);
+    mapper.addMixIn(UserMessage.class, UserMessageMixIn.class);
+    mapper.addMixIn(UserMessage.Builder.class, UserMessageBuilderMixIn.class);
+    mapper.addMixIn(SystemMessage.class, SystemMessageMixIn.class);
+    mapper.addMixIn(CustomMessage.class, CustomMessageMixIn.class);
+
+    mapper.addMixIn(AiMessage.class, AiMessageMixIn.class);
+    mapper.addMixIn(AiMessage.Builder.class, AiMessageBuilderMixIn.class);
+    mapper.addMixIn(ToolExecutionRequest.class, ToolExecutionRequestMixIn.class);
+    mapper.addMixIn(ToolExecutionRequest.Builder.class, ToolExecutionRequestBuilderMixIn.class);
+    mapper.addMixIn(ToolExecutionResultMessage.class, ToolExecutionResultMessageMixIn.class);
+    mapper.addMixIn(ToolExecutionResultMessage.Builder.class, ToolExecutionResultMessageBuilderMixIn.class);
+
+    mapper.addMixIn(Content.class, ContentMixIn.class);
+    mapper.addMixIn(TextContent.class, TextContentMixIn.class);
+    mapper.addMixIn(ImageContent.class, ImageContentMixIn.class);
+    mapper.addMixIn(Image.class, ImageMixIn.class);
+    mapper.addMixIn(Image.Builder.class, ImageBuilderMixIn.class);
+    mapper.addMixIn(AudioContent.class, AudioContentMixIn.class);
+    mapper.addMixIn(Audio.class, AudioMixIn.class);
+    mapper.addMixIn(Audio.Builder.class, AudioBuilderMixIn.class);
+    mapper.addMixIn(PdfFileContent.class, PdfFileContentMixIn.class);
+    mapper.addMixIn(PdfFile.class, PdfFileMixIn.class);
+    mapper.addMixIn(PdfFile.Builder.class, PdfFileBuilderMixIn.class);
+    mapper.addMixIn(VideoContent.class, VideoContentMixIn.class);
+    mapper.addMixIn(Video.class, VideoMixIn.class);
+    mapper.addMixIn(Video.Builder.class, VideoBuilderMixIn.class);
+
+    return mapper;
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+  private abstract static class MessageMixIn {
+  }
+
+  private abstract static class SystemMessageMixIn {
+    @JsonCreator
+    SystemMessageMixIn(@JsonProperty("text") String text) {
+    }
+  }
+
+  private abstract static class CustomMessageMixIn {
+    @JsonCreator
+    CustomMessageMixIn(@JsonProperty("attributes") Map<String, String> attributes) {
+    }
+  }
+
+  @JsonDeserialize(builder = UserMessage.Builder.class)
+  private abstract static class UserMessageMixIn {
+  }
+
+  @JsonPOJOBuilder
+  private abstract static class UserMessageBuilderMixIn {
+  }
+
+  @JsonDeserialize(builder = AiMessage.Builder.class)
+  private abstract static class AiMessageMixIn {
+  }
+
+  @JsonPOJOBuilder
+  private abstract static class AiMessageBuilderMixIn {
+  }
+
+  @JsonDeserialize(builder = ToolExecutionRequest.Builder.class)
+  private abstract static class ToolExecutionRequestMixIn {
+  }
+
+  @JsonPOJOBuilder
+  private abstract static class ToolExecutionRequestBuilderMixIn {
+  }
+
+  @JsonDeserialize(builder = ToolExecutionResultMessage.Builder.class)
+  private abstract static class ToolExecutionResultMessageMixIn {
+  }
+
+  @JsonPOJOBuilder
+  private abstract static class ToolExecutionResultMessageBuilderMixIn {
+    @JsonProperty("contents")
+    abstract ToolExecutionResultMessage.Builder contents(List<Content> contents);
+
+    @JsonIgnore
+    abstract ToolExecutionResultMessage.Builder contents(Content... contents);
+  }
+
+  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+  private abstract static class ContentMixIn {
+  }
+
+  private abstract static class TextContentMixIn {
+    @JsonCreator
+    TextContentMixIn(@JsonProperty("text") String text) {
+    }
+  }
+
+  private abstract static class ImageContentMixIn {
+    @JsonCreator
+    ImageContentMixIn(@JsonProperty("image") Image image, @JsonProperty("detailLevel") DetailLevel detailLevel) {
+    }
+  }
+
+  @JsonDeserialize(builder = Image.Builder.class)
+  private abstract static class ImageMixIn {
+  }
+
+  @JsonPOJOBuilder
+  private abstract static class ImageBuilderMixIn {
+  }
+
+  private abstract static class AudioContentMixIn {
+    @JsonCreator
+    AudioContentMixIn(@JsonProperty("audio") Audio audio) {
+    }
+  }
+
+  @JsonDeserialize(builder = Audio.Builder.class)
+  private abstract static class AudioMixIn {
+  }
+
+  @JsonPOJOBuilder
+  private abstract static class AudioBuilderMixIn {
+  }
+
+  private abstract static class PdfFileContentMixIn {
+    @JsonCreator
+    PdfFileContentMixIn(@JsonProperty("pdfFile") PdfFile pdfFile) {
+    }
+  }
+
+  @JsonDeserialize(builder = PdfFile.Builder.class)
+  private abstract static class PdfFileMixIn {
+  }
+
+  @JsonPOJOBuilder
+  private abstract static class PdfFileBuilderMixIn {
+  }
+
+  private abstract static class VideoContentMixIn {
+    @JsonCreator
+    VideoContentMixIn(@JsonProperty("video") Video video) {
+    }
+  }
+
+  @JsonDeserialize(builder = Video.Builder.class)
+  private abstract static class VideoMixIn {
+  }
+
+  @JsonPOJOBuilder
+  private abstract static class VideoBuilderMixIn {
+  }
+
+  private static class Messages {
+    private List<ChatMessage> messages;
+
+    @JsonCreator
+    public Messages(@JsonProperty("messages") List<ChatMessage> messages) {
+      this.messages = messages;
+    }
+  }
+}

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/memory/store/MessageSerializer.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/memory/store/MessageSerializer.java
@@ -1,47 +1,16 @@
 package com.axonivy.utils.smart.workflow.memory.store;
 
 import java.util.List;
-import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
-import dev.langchain4j.data.audio.Audio;
-import dev.langchain4j.data.image.Image;
-import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.AudioContent;
 import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.Content;
-import dev.langchain4j.data.message.CustomMessage;
-import dev.langchain4j.data.message.ImageContent;
-import dev.langchain4j.data.message.ImageContent.DetailLevel;
-import dev.langchain4j.data.message.PdfFileContent;
-import dev.langchain4j.data.message.SystemMessage;
-import dev.langchain4j.data.message.TextContent;
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
-import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.data.message.VideoContent;
-import dev.langchain4j.data.pdf.PdfFile;
-import dev.langchain4j.data.video.Video;
+import dev.langchain4j.data.message.ChatMessageDeserializer;
+import dev.langchain4j.data.message.ChatMessageSerializer;
 
 public class MessageSerializer {
 
-  static final ObjectMapper MAPPER = createMapper();
-
   public static List<ChatMessage> read(String json) {
     try {
-      return MAPPER.readValue(json, Messages.class).messages;
+      return ChatMessageDeserializer.messagesFromJson(json);
     } catch (Exception ex) {
       throw new RuntimeException("Failed to deserialize messages", ex);
     }
@@ -49,187 +18,9 @@ public class MessageSerializer {
 
   public static String write(List<ChatMessage> messages) {
     try {
-      Messages msgs = new Messages(messages);
-      return MAPPER.writeValueAsString(msgs);
+      return ChatMessageSerializer.messagesToJson(messages);
     } catch (Exception ex) {
       throw new RuntimeException("Failed to serialize messages", ex);
-    }
-  }
-
-  private static ObjectMapper createMapper() {
-    var mapper = new ObjectMapper();
-    mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
-    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    mapper.registerSubtypes(
-        new NamedType(UserMessage.class, UserMessage.class.getSimpleName()),
-        new NamedType(SystemMessage.class, SystemMessage.class.getSimpleName()),
-        new NamedType(AiMessage.class, AiMessage.class.getSimpleName()),
-        new NamedType(ToolExecutionResultMessage.class, ToolExecutionResultMessage.class.getSimpleName()),
-        new NamedType(CustomMessage.class, CustomMessage.class.getSimpleName()),
-
-        new NamedType(TextContent.class, TextContent.class.getSimpleName()),
-        new NamedType(ImageContent.class, ImageContent.class.getSimpleName()),
-        new NamedType(AudioContent.class, AudioContent.class.getSimpleName()),
-        new NamedType(PdfFileContent.class, PdfFileContent.class.getSimpleName()),
-        new NamedType(VideoContent.class, VideoContent.class.getSimpleName()));
-
-    mapper.addMixIn(ChatMessage.class, MessageMixIn.class);
-    mapper.addMixIn(UserMessage.class, UserMessageMixIn.class);
-    mapper.addMixIn(UserMessage.Builder.class, UserMessageBuilderMixIn.class);
-    mapper.addMixIn(SystemMessage.class, SystemMessageMixIn.class);
-    mapper.addMixIn(CustomMessage.class, CustomMessageMixIn.class);
-
-    mapper.addMixIn(AiMessage.class, AiMessageMixIn.class);
-    mapper.addMixIn(AiMessage.Builder.class, AiMessageBuilderMixIn.class);
-    mapper.addMixIn(ToolExecutionRequest.class, ToolExecutionRequestMixIn.class);
-    mapper.addMixIn(ToolExecutionRequest.Builder.class, ToolExecutionRequestBuilderMixIn.class);
-    mapper.addMixIn(ToolExecutionResultMessage.class, ToolExecutionResultMessageMixIn.class);
-    mapper.addMixIn(ToolExecutionResultMessage.Builder.class, ToolExecutionResultMessageBuilderMixIn.class);
-
-    mapper.addMixIn(Content.class, ContentMixIn.class);
-    mapper.addMixIn(TextContent.class, TextContentMixIn.class);
-    mapper.addMixIn(ImageContent.class, ImageContentMixIn.class);
-    mapper.addMixIn(Image.class, ImageMixIn.class);
-    mapper.addMixIn(Image.Builder.class, ImageBuilderMixIn.class);
-    mapper.addMixIn(AudioContent.class, AudioContentMixIn.class);
-    mapper.addMixIn(Audio.class, AudioMixIn.class);
-    mapper.addMixIn(Audio.Builder.class, AudioBuilderMixIn.class);
-    mapper.addMixIn(PdfFileContent.class, PdfFileContentMixIn.class);
-    mapper.addMixIn(PdfFile.class, PdfFileMixIn.class);
-    mapper.addMixIn(PdfFile.Builder.class, PdfFileBuilderMixIn.class);
-    mapper.addMixIn(VideoContent.class, VideoContentMixIn.class);
-    mapper.addMixIn(Video.class, VideoMixIn.class);
-    mapper.addMixIn(Video.Builder.class, VideoBuilderMixIn.class);
-
-    return mapper;
-  }
-
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-  private abstract static class MessageMixIn {
-  }
-
-  private abstract static class SystemMessageMixIn {
-    @JsonCreator
-    SystemMessageMixIn(@JsonProperty("text") String text) {
-    }
-  }
-
-  private abstract static class CustomMessageMixIn {
-    @JsonCreator
-    CustomMessageMixIn(@JsonProperty("attributes") Map<String, String> attributes) {
-    }
-  }
-
-  @JsonDeserialize(builder = UserMessage.Builder.class)
-  private abstract static class UserMessageMixIn {
-  }
-
-  @JsonPOJOBuilder
-  private abstract static class UserMessageBuilderMixIn {
-  }
-
-  @JsonDeserialize(builder = AiMessage.Builder.class)
-  private abstract static class AiMessageMixIn {
-  }
-
-  @JsonPOJOBuilder
-  private abstract static class AiMessageBuilderMixIn {
-  }
-
-  @JsonDeserialize(builder = ToolExecutionRequest.Builder.class)
-  private abstract static class ToolExecutionRequestMixIn {
-  }
-
-  @JsonPOJOBuilder
-  private abstract static class ToolExecutionRequestBuilderMixIn {
-  }
-
-  @JsonDeserialize(builder = ToolExecutionResultMessage.Builder.class)
-  private abstract static class ToolExecutionResultMessageMixIn {
-  }
-
-  @JsonPOJOBuilder
-  private abstract static class ToolExecutionResultMessageBuilderMixIn {
-    @JsonProperty("contents")
-    abstract ToolExecutionResultMessage.Builder contents(List<Content> contents);
-
-    @JsonIgnore
-    abstract ToolExecutionResultMessage.Builder contents(Content... contents);
-  }
-
-  @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-  private abstract static class ContentMixIn {
-  }
-
-  private abstract static class TextContentMixIn {
-    @JsonCreator
-    TextContentMixIn(@JsonProperty("text") String text) {
-    }
-  }
-
-  private abstract static class ImageContentMixIn {
-    @JsonCreator
-    ImageContentMixIn(@JsonProperty("image") Image image, @JsonProperty("detailLevel") DetailLevel detailLevel) {
-    }
-  }
-
-  @JsonDeserialize(builder = Image.Builder.class)
-  private abstract static class ImageMixIn {
-  }
-
-  @JsonPOJOBuilder
-  private abstract static class ImageBuilderMixIn {
-  }
-
-  private abstract static class AudioContentMixIn {
-    @JsonCreator
-    AudioContentMixIn(@JsonProperty("audio") Audio audio) {
-    }
-  }
-
-  @JsonDeserialize(builder = Audio.Builder.class)
-  private abstract static class AudioMixIn {
-  }
-
-  @JsonPOJOBuilder
-  private abstract static class AudioBuilderMixIn {
-  }
-
-  private abstract static class PdfFileContentMixIn {
-    @JsonCreator
-    PdfFileContentMixIn(@JsonProperty("pdfFile") PdfFile pdfFile) {
-    }
-  }
-
-  @JsonDeserialize(builder = PdfFile.Builder.class)
-  private abstract static class PdfFileMixIn {
-  }
-
-  @JsonPOJOBuilder
-  private abstract static class PdfFileBuilderMixIn {
-  }
-
-  private abstract static class VideoContentMixIn {
-    @JsonCreator
-    VideoContentMixIn(@JsonProperty("video") Video video) {
-    }
-  }
-
-  @JsonDeserialize(builder = Video.Builder.class)
-  private abstract static class VideoMixIn {
-  }
-
-  @JsonPOJOBuilder
-  private abstract static class VideoBuilderMixIn {
-  }
-
-  private static class Messages {
-    private List<ChatMessage> messages;
-
-    @JsonCreator
-    public Messages(@JsonProperty("messages") List<ChatMessage> messages) {
-      this.messages = messages;
     }
   }
 }


### PR DESCRIPTION
Ground work :construction: : persistent storage of the context for Human-in-the-Loop requests.


~~A lot of Jackson magic is required to get ChatMessages serialized. By doing it we can be absolutely certain that we can persist and load back all messages of the current memory.~~

~~Unfortunately there's no standard API available for that in the LangChain4j core. Translation from generic messages to serializable objects is a responsibility of the ChatModelProvider. 
See for instance  `dev.langchain4j.model.openai.internal.OpenAiUtils#toOpenAiMessages`.~~

~~By now I think serializing on our terms is the better choice:
:ballot_box_with_check: smaller compiled file and leaner dependencies in our main (smart-workflow.iar)
:ballot_box_with_check: agnostic: no specific provider knowledge in our core
:warning: tradeoff: we need to keep the API stable and follow LangChain4j changes~~
