### PR TITLE
Introduce ArchUnit tests to enforce module encapsulation 🥡️

### DIFF
--- a/smart-workflow-test/pom.xml
+++ b/smart-workflow-test/pom.xml
@@ -27,6 +27,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5</artifactId>
+      <version>1.4.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
       <version>2.0.5</version>

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/architecture/SmartProjects.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/architecture/SmartProjects.java
@@ -1,0 +1,61 @@
+package com.axonivy.utils.smart.workflow.architecture;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+interface SmartProjects {
+
+  static interface Dirs {
+    Path REPO_ROOT = Paths.get("..").normalize();
+    Path MODELS_DIR = REPO_ROOT.resolve("models");
+    Path SMART_WORKFLOW_DIR = REPO_ROOT.resolve("smart-workflow");
+    Path SMART_WORKFLOW_TEST_DIR = REPO_ROOT.resolve("smart-workflow-test");
+  }
+
+  public static Path core() {
+    return Dirs.SMART_WORKFLOW_DIR.resolve("target/classes");
+  }
+
+  public static List<Path> models() throws IOException {
+    return projectClassDirs(Dirs.MODELS_DIR, Integer.MAX_VALUE);
+  }
+
+  public static List<Path> consumersNoModels() throws IOException {
+    var consumers = new ArrayList<>(consumers());
+    var models = models();
+    consumers.removeAll(models);
+    return consumers;
+  }
+
+  public static List<Path> consumers() throws IOException {
+    return projectClassDirs(Dirs.REPO_ROOT, 3).stream()
+        .filter(classes -> !Dirs.SMART_WORKFLOW_DIR.equals(projectOf(classes)))
+        .filter(classes -> !Dirs.SMART_WORKFLOW_TEST_DIR.equals(projectOf(classes)))
+        .toList();
+  }
+
+  private static Path projectOf(Path classDir) {
+    return classDir.getParent().getParent();
+  }
+
+  private static List<Path> projectClassDirs(Path root, int maxDepth) throws IOException {
+    try (var projects = Files.walk(root, maxDepth)) {
+      return projects
+          .filter(path -> path.getFileName().toString().equals("pom.xml"))
+          .map(Path::getParent)
+          .filter(SmartProjects::hasJavaSources)
+          .map(projectDir -> projectDir.resolve("target/classes"))
+          .filter(Files::isDirectory)
+          .toList();
+    }
+  }
+
+  private static boolean hasJavaSources(Path projectDir) {
+    return Files.isDirectory(projectDir.resolve("src")) ||
+        Files.isDirectory(projectDir.resolve("src_generated"));
+  }
+}

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/architecture/TestArchitecture.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/architecture/TestArchitecture.java
@@ -1,0 +1,69 @@
+package com.axonivy.utils.smart.workflow.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+
+public class TestArchitecture {
+
+  @Test
+  void internalSmartWorkflowPackages_areNotUsedInConsumingBundles() throws IOException {
+    var smartWorkflowClasses = new ClassFileImporter()
+        .importPath(SmartProjects.core());
+    var consumerClasses = new ClassFileImporter()
+        .importPaths(SmartProjects.consumers());
+
+    var smartWorkflowInternalPackages = smartWorkflowClasses.stream()
+        .map(JavaClass::getPackageName)
+        .filter(pkg -> pkg.contains(".internal"))
+        .distinct()
+        .toList();
+
+    var resideInSmartWorkflowInternalPackages = new DescribedPredicate<JavaClass>(
+        "reside in smart-workflow 'internal' packages") {
+      @Override
+      public boolean test(JavaClass input) {
+        return smartWorkflowInternalPackages.stream()
+            .anyMatch(pkg -> input.getPackageName().equals(pkg) || input.getPackageName().startsWith(pkg + "."));
+      }
+    };
+
+    noClasses()
+        .should().dependOnClassesThat(resideInSmartWorkflowInternalPackages)
+        .because("smart-workflow internal packages are reserved for smart-workflow-test")
+        .check(consumerClasses);
+  }
+
+  @Test
+  void modelsPackages_areNotUsedInConsumingBundles() throws IOException {
+    var modelClasses = new ClassFileImporter()
+        .importPaths(SmartProjects.models());
+    var consumerClasses = new ClassFileImporter()
+        .importPaths(SmartProjects.consumersNoModels());
+
+    var modelPackages = modelClasses.stream()
+        .map(JavaClass::getPackageName)
+        .distinct()
+        .toList();
+
+    var resideInModelPackages = new DescribedPredicate<JavaClass>("reside in 'model' packages") {
+      @Override
+      public boolean test(JavaClass input) {
+        return modelPackages.stream()
+            .anyMatch(pkg -> input.getPackageName().equals(pkg) || input.getPackageName().startsWith(pkg + "."));
+      }
+    };
+
+    noClasses()
+        .should().dependOnClassesThat(resideInModelPackages)
+        .because("models are only accessible through SPI; direct access is prohibited")
+        .check(consumerClasses);
+  }
+
+}


### PR DESCRIPTION
Enforce architecture guidelines;
- no leacking of internals to consuming projects
- no using of "model" internas in consuming projects

Up till now I tried to stick to these rules in reviews, 
now we have it as code that fails and guides change contributors. :fast_forward: ... faster feedback loop than human reviews :1st_place_medal: 