### PR TITLE
Fix: OpenSearchRag can not be installed form the Market 📦️

### DIFF
--- a/smart-workflow-product/product.json
+++ b/smart-workflow-product/product.json
@@ -46,6 +46,13 @@
             "version": "${version}",
             "type": "iar",
             "importInWorkspace": false
+          },
+          {
+            "groupId": "com.axonivy.utils.ai",
+            "artifactId": "smart-workflow-opensearch-rag",
+            "version": "${version}",
+            "type": "iar",
+            "importInWorkspace": false
           }
         ],
         "repositories": [

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/market/ProductJson.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/market/ProductJson.java
@@ -1,0 +1,44 @@
+package com.axonivy.utils.smart.workflow.market;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import com.axonivy.utils.smart.workflow.utils.JsonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class ProductJson {
+
+  private static final JsonNode PRODUCT = productJson();
+
+  public static List<String> installerArtifactIds() {
+    return installerArtifactIds(PRODUCT);
+  }
+
+  private static JsonNode productJson() {
+    try {
+      var where = ProductJson.class.getResource("/").toURI();
+      var repo = Path.of(where).getParent().getParent().getParent();
+      var product = repo.resolve("smart-workflow-product").resolve("product.json");
+      try(var in = Files.newInputStream(product, StandardOpenOption.READ)){
+        return JsonUtils.getObjectMapper().readTree(in);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load product.json for test", e);
+    }
+  }
+
+  private static List<String> installerArtifactIds(JsonNode product) {
+    return stream(product.path("installers"))
+        .flatMap(installer -> stream(installer.path("data").path("projects")))
+        .map(project -> project.path("artifactId").asText())
+        .toList();
+  }
+
+  private static Stream<JsonNode> stream(JsonNode node) {
+    return StreamSupport.stream(node.spliterator(), false);
+  }
+}

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/TestChatModelProviders.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/TestChatModelProviders.java
@@ -2,25 +2,20 @@ package com.axonivy.utils.smart.workflow.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import com.axonivy.utils.smart.workflow.market.ProductJson;
 import com.axonivy.utils.smart.workflow.model.anthropic.internal.AnthropicServiceConnector.AnthropicConf;
 import com.axonivy.utils.smart.workflow.model.azureopenai.internal.AzureOpenAiConf;
 import com.axonivy.utils.smart.workflow.model.spi.ChatModelProvider;
 import com.axonivy.utils.smart.workflow.model.spi.ChatModelProvider.ModelOptions;
 import com.axonivy.utils.smart.workflow.spi.internal.SpiLoader;
-import com.axonivy.utils.smart.workflow.utils.JsonUtils;
-import com.fasterxml.jackson.databind.JsonNode;
 
 import ch.ivyteam.ivy.environment.AppFixture;
 import ch.ivyteam.ivy.environment.IvyTest;
@@ -30,8 +25,6 @@ import dev.langchain4j.model.chat.listener.ChatModelResponseContext;
 
 @IvyTest
 class TestChatModelProviders {
-
-  private static final JsonNode PRODUCT = productJson();
 
   @BeforeEach
   void setUp(AppFixture fixture) {
@@ -80,34 +73,10 @@ class TestChatModelProviders {
       return; // dummy provider is not actually installed, just for testing resolution
     }
     var provider = ChatModelFactory.create(providerName).orElseThrow();
-    var artifactIds = installerArtifactIds(PRODUCT);
+    var artifactIds = ProductJson.installerArtifactIds();
     assertThat(artifactIds)
       .as("provider is installable as extra market product")
       .contains(installerName(provider));
-  }
-
-  private static List<String> installerArtifactIds(JsonNode product) {
-    return stream(product.path("installers"))
-        .flatMap(installer -> stream(installer.path("data").path("projects")))
-        .map(project -> project.path("artifactId").asText())
-        .toList();
-  }
-
-  private static Stream<JsonNode> stream(JsonNode node) {
-    return StreamSupport.stream(node.spliterator(), false);
-  }
-
-  private static JsonNode productJson() {
-    try {
-      var where = TestChatModelProviders.class.getResource("/").toURI();
-      var repo = Path.of(where).getParent().getParent().getParent();
-      var product = repo.resolve("smart-workflow-product").resolve("product.json");
-      try(var in = Files.newInputStream(product, StandardOpenOption.READ)){
-        return JsonUtils.getObjectMapper().readTree(in);
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to load product.json for test", e);
-    }
   }
 
   private static String installerName(ChatModelProvider provider) {

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/rag/TestRagProviders.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/rag/TestRagProviders.java
@@ -1,0 +1,39 @@
+package com.axonivy.utils.smart.workflow.rag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.axonivy.utils.smart.workflow.market.ProductJson;
+import com.axonivy.utils.smart.workflow.spi.internal.SpiLoader;
+import com.axonivy.utils.smart.workflow.tools.provider.SmartWorkflowToolsProvider;
+
+import ch.ivyteam.ivy.environment.IvyTest;
+
+@IvyTest
+class TestRagProviders {
+
+  @ParameterizedTest
+  @MethodSource("ragProviders")
+  void installer_promotesProvider(SmartWorkflowToolsProvider provider) throws Exception {
+    var artifactIds = ProductJson.installerArtifactIds();
+    assertThat(artifactIds)
+        .as("RAG provider is installable as extra market product")
+        .contains(installerName(provider));
+  }
+
+  private static String installerName(SmartWorkflowToolsProvider provider) throws Exception {
+    var vendor = StringUtils.substringBefore(provider.getClass().getSimpleName(), "RagToolProvider") ;
+    return "smart-workflow-"+vendor.toLowerCase()+"-rag";
+  }
+
+  static Stream<SmartWorkflowToolsProvider> ragProviders() {
+    var classLoader = TestRagProviders.class.getClassLoader();
+    return SpiLoader.findImpl(SmartWorkflowToolsProvider.class, classLoader).stream()
+        .filter(p -> p.getClass().getPackageName().contains(".rag."));
+  }
+}


### PR DESCRIPTION
OpenSearchRag was not selectable to be installed from the Market-installer dialog:
<img width="641" height="221" alt="workflow-installer-rag-missing" src="https://github.com/user-attachments/assets/04eca4e4-9d33-434c-b26b-90125acdbd1e" />

... in most cases it was provided anyway, but only by "accident" through the smart-workflow-demo dependency to it.