### PR TITLE
Include LangChain4j beta version updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,24 @@
         "org.assertj:*"
       ],
       "automerge": true
+    },
+    {
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "/^dev\\.langchain4j:.*/"
+      ],
+      "groupName": "langchain4j"
+    },
+    {
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "dev.langchain4j:langchain4j-community-web-search-engine-duckduckgo"
+      ],
+      "ignoreUnstable": false
     }
   ]
 }


### PR DESCRIPTION
Can't really test it without merging it ... so I do it directly

at least the config is valid: `npx --yes --package renovate -- renovate-config-validator`