### PR TITLE
Opensearch dev container follow-up

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -23,7 +23,7 @@ services:
     ports:
       - "127.0.0.1:9200:9200"
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:9200/_cat/health || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s' || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 12

--- a/doc/RAG.md
+++ b/doc/RAG.md
@@ -68,3 +68,7 @@ AI.DefaultProvider           = OpenAI          # or AzureOpenAI / Gemini
 AI.RAG.OpenSearch.Url        = https://my-opensearch.us-east-1.es.amazonaws.com
 # AI.RAG.EmbeddingModel.Provider can be left blank if AI.DefaultProvider supports embedding
 ```
+
+> **Tip:** Our [Devcontainer](dev/DEVCONTAINER.md) is pre-configured with an
+> OpenSearch service, so you can skip the server setup and `AI.RAG.OpenSearch.Url`
+> configuration. In that environment you only need to define the AI Provider API key.


### PR DESCRIPTION
- Link RAG docs to the Devcontainer setup
- Harden OpenSearch healthcheck to wait for usable cluster status