### PR TITLE
Fix: OpenInference multimodal spans and replace null output with tool call names

### DIFF
--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/observability/TestOpenInferenceSpans.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/observability/TestOpenInferenceSpans.java
@@ -19,10 +19,14 @@ import com.axonivy.utils.smart.workflow.test.TestToolUserData;
 import com.axonivy.utils.smart.workflow.tools.math.MathToolChat;
 import com.axonivy.utils.smart.workflow.tools.ntools.MultiToolChat;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.AudioContent;
 import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.PdfFileContent;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.message.VideoContent;
 
 import ch.ivyteam.ivy.bpm.engine.client.BpmClient;
 import ch.ivyteam.ivy.bpm.engine.client.element.BpmProcess;
@@ -69,10 +73,28 @@ class TestOpenInferenceSpans {
     var pdfOnly = UserMessage.from(PdfFileContent.from("http://example.com/doc.pdf", "application/pdf"));
     assertThat(OpenInferenceCollector.textOf(pdfOnly)).isEqualTo("[pdf]");
 
+    var audioOnly = UserMessage.from(AudioContent.from("http://example.com/clip.mp3", "audio/mp3"));
+    assertThat(OpenInferenceCollector.textOf(audioOnly)).isEqualTo("[audio]");
+
+    var videoOnly = UserMessage.from(VideoContent.from("http://example.com/clip.mp4", "video/mp4"));
+    assertThat(OpenInferenceCollector.textOf(videoOnly)).isEqualTo("[video]");
+
     var mixed = UserMessage.from(
         TextContent.from("describe this:"),
         ImageContent.from("http://example.com/img.png", "image/png"));
     assertThat(OpenInferenceCollector.textOf(mixed)).isEqualTo("describe this: [image]");
+  }
+
+  @Test
+  void resolveContent_showsToolCallNamesInsteadOfNull() {
+    var toolCallOnly = AiMessage.from(
+        ToolExecutionRequest.builder().id("1").name("extractHeaderInfo").arguments("{}").build(),
+        ToolExecutionRequest.builder().id("2").name("extractLineItems").arguments("{}").build());
+    assertThat(OpenInferenceCollector.resolveContent(toolCallOnly))
+        .isEqualTo("[tool calls: extractHeaderInfo, extractLineItems]");
+
+    var textResponse = AiMessage.from("Here is the result.");
+    assertThat(OpenInferenceCollector.resolveContent(textResponse)).isEqualTo("Here is the result.");
   }
 
   @Test

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/observability/TestOpenInferenceSpans.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/observability/TestOpenInferenceSpans.java
@@ -14,9 +14,15 @@ import com.axonivy.utils.ai.mock.MockOpenAI;
 import com.axonivy.utils.smart.workflow.client.OpenAiTestClient;
 import com.axonivy.utils.smart.workflow.model.openai.internal.OpenAiServiceConnector.OpenAiConf;
 import com.axonivy.utils.smart.workflow.observability.openinference.OpenInferenceTracing;
+import com.axonivy.utils.smart.workflow.observability.openinference.internal.OpenInferenceCollector;
 import com.axonivy.utils.smart.workflow.test.TestToolUserData;
 import com.axonivy.utils.smart.workflow.tools.math.MathToolChat;
 import com.axonivy.utils.smart.workflow.tools.ntools.MultiToolChat;
+
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.PdfFileContent;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.UserMessage;
 
 import ch.ivyteam.ivy.bpm.engine.client.BpmClient;
 import ch.ivyteam.ivy.bpm.engine.client.element.BpmProcess;
@@ -45,8 +51,28 @@ class TestOpenInferenceSpans {
 
   @AfterEach
   void clean() throws InterruptedException{
+    if (this.tracer == null) {
+      return;
+    }
     Thread.sleep(1_000); // wait for async spans to be flushed (fail on CI without this)
     this.tracer.slowTraces().clear();
+  }
+
+  @Test
+  void textOf_extractsTextFromMultimodalMessage() {
+    var textOnly = UserMessage.from(TextContent.from("hello"));
+    assertThat(OpenInferenceCollector.textOf(textOnly)).isEqualTo("hello");
+
+    var imageOnly = UserMessage.from(ImageContent.from("http://example.com/img.png", "image/png"));
+    assertThat(OpenInferenceCollector.textOf(imageOnly)).isEqualTo("[image]");
+
+    var pdfOnly = UserMessage.from(PdfFileContent.from("http://example.com/doc.pdf", "application/pdf"));
+    assertThat(OpenInferenceCollector.textOf(pdfOnly)).isEqualTo("[pdf]");
+
+    var mixed = UserMessage.from(
+        TextContent.from("describe this:"),
+        ImageContent.from("http://example.com/img.png", "image/png"));
+    assertThat(OpenInferenceCollector.textOf(mixed)).isEqualTo("describe this: [image]");
   }
 
   @Test
@@ -203,7 +229,7 @@ class TestOpenInferenceSpans {
 
     assertThat(attrs)
       .as("record tool call response attributes")
-      .containsEntry("llm.output_messages.0.message.content", "null")
+      .containsEntry("llm.output_messages.0.message.content", "[tool calls: add]")
       .containsEntry("llm.output_messages.0.message.role", "assistant")
       .containsEntry("llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments", "{\"a\":1984,\"b\":41}")
       .containsEntry("llm.output_messages.0.message.tool_calls.0.tool_call.function.name", "add")
@@ -213,7 +239,7 @@ class TestOpenInferenceSpans {
       .containsEntry("llm.token_count.prompt", "102")
       .containsEntry("llm.token_count.total", "120")
       .containsEntry("output.mime_type", "text/plain")
-      .containsEntry("output.value", "null");
+      .containsEntry("output.value", "[tool calls: add]");
   }
 
   private void assertToolDoneAttrs(Map<String, String> attrs) {

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/OpenInferenceTracing.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/OpenInferenceTracing.java
@@ -18,7 +18,6 @@ import com.axonivy.utils.smart.workflow.utils.IvyVar;
 import ch.ivyteam.ivy.trace.Attribute;
 import ch.ivyteam.ivy.trace.Span;
 import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.observability.api.event.AiServiceCompletedEvent;
 import dev.langchain4j.observability.api.event.AiServiceErrorEvent;
 import dev.langchain4j.observability.api.event.AiServiceRequestIssuedEvent;
@@ -180,7 +179,7 @@ public class OpenInferenceTracing implements AiListenerProvider {
     public void onEvent(InputGuardrailExecutedEvent event) {
       String inputMessage = options.hideInput ? null : Optional.ofNullable(event.request())
           .map(r -> r.userMessage())
-          .map(UserMessage::singleText)
+          .map(OpenInferenceCollector::textOf)
           .orElse(null);
       String guardrailName = event.guardrailClass().getSimpleName();
       traceGuardrail(event, "INPUT", inputMessage, guardrailName);

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/OpenInferenceTracing.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/OpenInferenceTracing.java
@@ -193,7 +193,7 @@ public class OpenInferenceTracing implements AiListenerProvider {
       String outputMessage = options.hideOutput ? null : Optional.ofNullable(event.request())
           .map(r -> r.responseFromLLM())
           .map(r -> r.aiMessage())
-          .map(AiMessage::text)
+          .map(OpenInferenceCollector::resolveContent)
           .orElse(null);
       String guardrailName = event.guardrailClass().getSimpleName();
       traceGuardrail(event, "OUTPUT", outputMessage, guardrailName);

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/internal/OpenInferenceCollector.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/internal/OpenInferenceCollector.java
@@ -13,6 +13,8 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
@@ -73,6 +75,18 @@ public class OpenInferenceCollector {
     return content.getClass().getSimpleName()
         .replaceAll("(?i)(File)?Content$", "")
         .toLowerCase();
+  }
+
+  public static String resolveContent(AiMessage aiMessage) {
+    if (aiMessage.text() != null) {
+      return aiMessage.text();
+    }
+    if (aiMessage.hasToolExecutionRequests()) {
+      return aiMessage.toolExecutionRequests().stream()
+          .map(ToolExecutionRequest::name)
+          .collect(Collectors.joining(", ", "[tool calls: ", "]"));
+    }
+    return null;
   }
 
   public void onRequest(ChatRequest request) {

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/internal/OpenInferenceCollector.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/internal/OpenInferenceCollector.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.arize.semconv.trace.SemanticConventions;
@@ -12,6 +13,8 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 
@@ -58,6 +61,18 @@ public class OpenInferenceCollector {
 
   public Map<String, Object> getAttributes() {
     return Collections.unmodifiableMap(attributes);
+  }
+
+  public static String textOf(UserMessage msg) {
+    return msg.contents().stream()
+        .map(c -> c instanceof TextContent tc ? tc.text() : "[" + contentLabel(c) + "]")
+        .collect(Collectors.joining(" "));
+  }
+
+  private static String contentLabel(Object content) {
+    return content.getClass().getSimpleName()
+        .replaceAll("(?i)(File)?Content$", "")
+        .toLowerCase();
   }
 
   public void onRequest(ChatRequest request) {

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/internal/RequestRecorder.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/internal/RequestRecorder.java
@@ -84,7 +84,7 @@ class RequestRecorder {
       String messagesJson = OpenInferenceCollector.objectMapper.writeValueAsString(messagesList);
       attributes.put(SemanticConventions.INPUT_VALUE, messagesJson);
       attributes.put(SemanticConventions.INPUT_MIME_TYPE, "application/json");
-    } catch (JsonProcessingException ex) {
+    } catch (Exception ex) {
       Ivy.log().warn("Failed to serialize input messages", ex);
     }
   }
@@ -127,7 +127,7 @@ class RequestRecorder {
         case USER -> {
           messageMap.put("role", "user");
           if (message instanceof UserMessage userMessage) {
-            messageMap.put("content", userMessage.singleText());
+            messageMap.put("content", OpenInferenceCollector.textOf(userMessage));
           }
         }
         case CUSTOM -> {

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/internal/ResponseRecorder.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/internal/ResponseRecorder.java
@@ -3,11 +3,9 @@ package com.axonivy.utils.smart.workflow.observability.openinference.internal;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.arize.semconv.trace.SemanticConventions;
 
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.response.ChatResponse;
 
@@ -46,21 +44,9 @@ class ResponseRecorder {
     AiMessage aiMessage = response.aiMessage();
     String prefix = String.format("%s.%d.", SemanticConventions.LLM_OUTPUT_MESSAGES, 0);
     attributes.put(prefix + SemanticConventions.MESSAGE_ROLE, "assistant");
-    attributes.put(prefix + SemanticConventions.MESSAGE_CONTENT, resolveContent(aiMessage));
+    attributes.put(prefix + SemanticConventions.MESSAGE_CONTENT, OpenInferenceCollector.resolveContent(aiMessage));
     attributes.putAll(ToolRecorder.toolRequest(prefix, aiMessage.toolExecutionRequests()));
-    attributes.put(SemanticConventions.OUTPUT_VALUE, resolveContent(aiMessage));
+    attributes.put(SemanticConventions.OUTPUT_VALUE, OpenInferenceCollector.resolveContent(aiMessage));
     attributes.put(SemanticConventions.OUTPUT_MIME_TYPE, "text/plain");
-  }
-
-  private static String resolveContent(AiMessage aiMessage) {
-    if (aiMessage.text() != null) {
-      return aiMessage.text();
-    }
-    if (aiMessage.hasToolExecutionRequests()) {
-      return aiMessage.toolExecutionRequests().stream()
-          .map(ToolExecutionRequest::name)
-          .collect(Collectors.joining(", ", "[tool calls: ", "]"));
-    }
-    return null;
   }
 }

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/internal/ResponseRecorder.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/internal/ResponseRecorder.java
@@ -3,9 +3,11 @@ package com.axonivy.utils.smart.workflow.observability.openinference.internal;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.arize.semconv.trace.SemanticConventions;
 
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.response.ChatResponse;
 
@@ -44,9 +46,21 @@ class ResponseRecorder {
     AiMessage aiMessage = response.aiMessage();
     String prefix = String.format("%s.%d.", SemanticConventions.LLM_OUTPUT_MESSAGES, 0);
     attributes.put(prefix + SemanticConventions.MESSAGE_ROLE, "assistant");
-    attributes.put(prefix + SemanticConventions.MESSAGE_CONTENT, aiMessage.text());
+    attributes.put(prefix + SemanticConventions.MESSAGE_CONTENT, resolveContent(aiMessage));
     attributes.putAll(ToolRecorder.toolRequest(prefix, aiMessage.toolExecutionRequests()));
-    attributes.put(SemanticConventions.OUTPUT_VALUE, aiMessage.text());
+    attributes.put(SemanticConventions.OUTPUT_VALUE, resolveContent(aiMessage));
     attributes.put(SemanticConventions.OUTPUT_MIME_TYPE, "text/plain");
+  }
+
+  private static String resolveContent(AiMessage aiMessage) {
+    if (aiMessage.text() != null) {
+      return aiMessage.text();
+    }
+    if (aiMessage.hasToolExecutionRequests()) {
+      return aiMessage.toolExecutionRequests().stream()
+          .map(ToolExecutionRequest::name)
+          .collect(Collectors.joining(", ", "[tool calls: ", "]"));
+    }
+    return null;
   }
 }


### PR DESCRIPTION
Close #292 
- fix multimodal spans to include tool call names instead of null output
- fixed OpenInference crashes on media input