### PR TITLE
Adapt langchain4j 1.16 API guardrailName() and drop Netty HTTP client 🗓️

### DIFF
--- a/models/smart-workflow-azure-openai/pom.xml
+++ b/models/smart-workflow-azure-openai/pom.xml
@@ -45,40 +45,8 @@
           <artifactId>langchain4j-core</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-tcnative-boringssl-static</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-tcnative-classes</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-epoll</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-classes-epoll</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-kqueue</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-classes-kqueue</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-transport-native-unix-common</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.projectreactor.netty</groupId>
-          <artifactId>reactor-netty-http</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.projectreactor.netty</groupId>
-          <artifactId>reactor-netty-core</artifactId>
+          <groupId>com.azure</groupId>
+          <artifactId>azure-core-http-netty</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/governance/history/TestGuardrailHistoryRecording.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/governance/history/TestGuardrailHistoryRecording.java
@@ -14,6 +14,9 @@ import com.axonivy.utils.smart.workflow.governance.history.listener.OutputGuardr
 import com.axonivy.utils.smart.workflow.governance.history.recorder.internal.ChatHistoryRepository;
 import com.axonivy.utils.smart.workflow.guardrails.adapter.InputGuardrailAdapter;
 import com.axonivy.utils.smart.workflow.guardrails.adapter.OutputGuardrailAdapter;
+import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailResult;
+import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowInputGuardrail;
+import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowOutputGuardrail;
 
 import ch.ivyteam.ivy.environment.IvyTest;
 import dev.langchain4j.data.message.AiMessage;
@@ -56,7 +59,7 @@ public class TestGuardrailHistoryRecording {
     assertThat(guardrails).hasSize(1);
 
     var guardrail = guardrails.get(0);
-    assertThat(guardrail.guardrailName()).isEqualTo("InputGuardrailAdapter");
+    assertThat(guardrail.guardrailName()).isEqualTo("TestInputGuardrail");
     assertThat(guardrail.type()).isEqualTo("INPUT");
     assertThat(guardrail.result()).isEqualTo("SUCCESS");
     assertThat(guardrail.message()).isEqualTo("Hello agent");
@@ -107,6 +110,9 @@ public class TestGuardrailHistoryRecording {
     public dev.langchain4j.model.chat.response.ChatResponse execute(java.util.List<dev.langchain4j.data.message.ChatMessage> messages) { return null; }
   };
 
+  private static final InputGuardrailAdapter INPUT_ADAPTER = new InputGuardrailAdapter(new TestInputGuardrail());
+  private static final OutputGuardrailAdapter OUTPUT_ADAPTER = new OutputGuardrailAdapter(new TestOutputGuardrail());
+
   private InputGuardrailExecutedEvent buildInputEvent(String userText, InputGuardrailResult result, Duration duration) {
     var invocationCtx = InvocationContext.builder()
         .invocationId(UUID.randomUUID())
@@ -124,7 +130,8 @@ public class TestGuardrailHistoryRecording {
         .build();
     return InputGuardrailExecutedEvent.builder()
         .invocationContext(invocationCtx)
-        .guardrailClass(InputGuardrailAdapter.class)
+        .guardrailClass(INPUT_ADAPTER.getClass())
+        .guardrailName(INPUT_ADAPTER.name())
         .request(request)
         .result(result)
         .duration(duration)
@@ -152,10 +159,25 @@ public class TestGuardrailHistoryRecording {
         .build();
     return OutputGuardrailExecutedEvent.builder()
         .invocationContext(invocationCtx)
-        .guardrailClass(OutputGuardrailAdapter.class)
+        .guardrailClass(OUTPUT_ADAPTER.getClass())
+        .guardrailName(OUTPUT_ADAPTER.name())
         .request(request)
         .result(result)
         .duration(duration)
         .build();
+  }
+
+  private static class TestInputGuardrail implements SmartWorkflowInputGuardrail {
+    @Override
+    public GuardrailResult evaluate(String message) {
+      return GuardrailResult.allow();
+    }
+  }
+
+  private static class TestOutputGuardrail implements SmartWorkflowOutputGuardrail {
+    @Override
+    public GuardrailResult evaluate(String message) {
+      return GuardrailResult.allow();
+    }
   }
 }

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/governance/history/TestInputGuardrailListener.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/governance/history/TestInputGuardrailListener.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test;
 
 import com.axonivy.utils.smart.workflow.governance.history.listener.InputGuardrailListener;
 import com.axonivy.utils.smart.workflow.guardrails.adapter.InputGuardrailAdapter;
+import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailResult;
+import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowInputGuardrail;
 
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.guardrail.GuardrailRequestParams;
@@ -43,7 +45,7 @@ public class TestInputGuardrailListener {
 
     assertThat(captured).hasSize(1);
     var entry = captured.get(0);
-    assertThat(entry.name()).isEqualTo("InputGuardrailAdapter");
+    assertThat(entry.name()).isEqualTo("TestInputGuardrail");
     assertThat(entry.type()).isEqualTo("INPUT");
     assertThat(entry.result()).isEqualTo("SUCCESS");
     assertThat(entry.message()).isEqualTo("What is the weather?");
@@ -80,6 +82,14 @@ public class TestInputGuardrailListener {
   }
 
   private static final InputGuardrail GUARDRAIL_HELPER = new InputGuardrail() {};
+  private static final InputGuardrailAdapter INPUT_ADAPTER = new InputGuardrailAdapter(new TestInputGuardrail());
+
+  private static class TestInputGuardrail implements SmartWorkflowInputGuardrail {
+    @Override
+    public GuardrailResult evaluate(String message) {
+      return GuardrailResult.allow();
+    }
+  }
 
   private InputGuardrailExecutedEvent buildEvent(String userText, InputGuardrailResult result, Duration duration) {
     var invocationCtx = InvocationContext.builder()
@@ -97,7 +107,8 @@ public class TestInputGuardrailListener {
         .build();
     return InputGuardrailExecutedEvent.builder()
         .invocationContext(invocationCtx)
-        .guardrailClass(InputGuardrailAdapter.class)
+        .guardrailClass(INPUT_ADAPTER.getClass())
+        .guardrailName(INPUT_ADAPTER.name())
         .request(request)
         .result(result)
         .duration(duration)

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/governance/history/TestOutputGuardrailListener.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/governance/history/TestOutputGuardrailListener.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test;
 
 import com.axonivy.utils.smart.workflow.governance.history.listener.OutputGuardrailListener;
 import com.axonivy.utils.smart.workflow.guardrails.adapter.OutputGuardrailAdapter;
+import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailResult;
+import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowOutputGuardrail;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.guardrail.ChatExecutor;
@@ -45,7 +47,7 @@ public class TestOutputGuardrailListener {
 
     assertThat(captured).hasSize(1);
     var entry = captured.get(0);
-    assertThat(entry.name()).isEqualTo("OutputGuardrailAdapter");
+    assertThat(entry.name()).isEqualTo("TestOutputGuardrail");
     assertThat(entry.type()).isEqualTo("OUTPUT");
     assertThat(entry.result()).isEqualTo("SUCCESS");
     assertThat(entry.message()).isEqualTo("The weather is sunny today.");
@@ -82,6 +84,14 @@ public class TestOutputGuardrailListener {
   }
 
   private static final OutputGuardrail GUARDRAIL_HELPER = new OutputGuardrail() {};
+  private static final OutputGuardrailAdapter OUTPUT_ADAPTER = new OutputGuardrailAdapter(new TestOutputGuardrail());
+
+  private static class TestOutputGuardrail implements SmartWorkflowOutputGuardrail {
+    @Override
+    public GuardrailResult evaluate(String message) {
+      return GuardrailResult.allow();
+    }
+  }
   private static final ChatExecutor NOOP_CHAT_EXECUTOR = new ChatExecutor() {
     @Override
     public dev.langchain4j.model.chat.response.ChatResponse execute() { return null; }
@@ -109,7 +119,8 @@ public class TestOutputGuardrailListener {
         .build();
     return OutputGuardrailExecutedEvent.builder()
         .invocationContext(invocationCtx)
-        .guardrailClass(OutputGuardrailAdapter.class)
+        .guardrailClass(OUTPUT_ADAPTER.getClass())
+        .guardrailName(OUTPUT_ADAPTER.name())
         .request(request)
         .result(result)
         .duration(duration)

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/observability/TestOpenInferenceSpans.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/observability/TestOpenInferenceSpans.java
@@ -184,11 +184,11 @@ class TestOpenInferenceSpans {
     var rootSpan = spans.getFirst().rootSpan();
     var agent = findChild(rootSpan, "AI Agent").findFirst().orElseThrow();
 
-    var inputGuardrail = findChild(agent, "InputGuardrailAdapter").findFirst().orElseThrow();
+    var inputGuardrail = findChild(agent, "PromptInjectionInputGuardrail").findFirst().orElseThrow();
     var inputAttrs = mapOf(inputGuardrail.attributes());
     assertThat(inputAttrs)
         .containsEntry("openinference.span.kind", "GUARDRAIL")
-        .containsEntry("validator_name", "InputGuardrailAdapter")
+        .containsEntry("validator_name", "PromptInjectionInputGuardrail")
         .containsEntry("validator_on_fail", "exception")
         .containsEntry("guardrail.type", "INPUT")
         .containsEntry("guardrail.result", "SUCCESS")
@@ -197,11 +197,11 @@ class TestOpenInferenceSpans {
         .containsEntry("output.value", "pass")
         .containsEntry("output.mime_type", "text/plain");
 
-    var outputGuardrail = findChild(agent, "OutputGuardrailAdapter").findFirst().orElseThrow();
+    var outputGuardrail = findChild(agent, "SensitiveDataOutputGuardrail").findFirst().orElseThrow();
     var outputAttrs = mapOf(outputGuardrail.attributes());
     assertThat(outputAttrs)
         .containsEntry("openinference.span.kind", "GUARDRAIL")
-        .containsEntry("validator_name", "OutputGuardrailAdapter")
+        .containsEntry("validator_name", "SensitiveDataOutputGuardrail")
         .containsEntry("validator_on_fail", "exception")
         .containsEntry("guardrail.type", "OUTPUT")
         .containsEntry("guardrail.result", "SUCCESS")

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/governance/history/listener/InputGuardrailListener.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/governance/history/listener/InputGuardrailListener.java
@@ -21,7 +21,7 @@ public class InputGuardrailListener implements InputGuardrailExecutedListener {
 
   @Override
   public void onEvent(InputGuardrailExecutedEvent event) {
-    String guardrailName = event.guardrailClass().getSimpleName();
+    String guardrailName = event.guardrailName();
     String result = event.result().result().name();
     String rawMessage = Optional.ofNullable(event.request())
         .map(r -> r.userMessage())

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/governance/history/listener/OutputGuardrailListener.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/governance/history/listener/OutputGuardrailListener.java
@@ -20,7 +20,7 @@ public class OutputGuardrailListener implements OutputGuardrailExecutedListener 
 
   @Override
   public void onEvent(OutputGuardrailExecutedEvent event) {
-    String guardrailName = event.guardrailClass().getSimpleName();
+    String guardrailName = event.guardrailName();
     String result = event.result().result().name();
     String message = Optional.ofNullable(event.request())
         .map(r -> r.responseFromLLM())

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/adapter/AbstractGuardrailAdapter.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/adapter/AbstractGuardrailAdapter.java
@@ -14,6 +14,10 @@ public abstract class AbstractGuardrailAdapter<D extends SmartWorkflowGuardrail>
     return delegate;
   }
 
+  public String name() {
+    return delegate != null ? delegate.getClass().getSimpleName() : getClass().getSimpleName();
+  }
+
   @Override
   public int hashCode() {
     return delegate != null ? delegate.getClass().getName().hashCode() : 0;

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/adapter/AbstractGuardrailAdapter.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/adapter/AbstractGuardrailAdapter.java
@@ -15,7 +15,7 @@ public abstract class AbstractGuardrailAdapter<D extends SmartWorkflowGuardrail>
   }
 
   public String name() {
-    return delegate != null ? delegate.getClass().getSimpleName() : getClass().getSimpleName();
+    return delegate != null ? delegate.name() : getClass().getSimpleName();
   }
 
   @Override

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/OpenInferenceTracing.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/observability/openinference/OpenInferenceTracing.java
@@ -181,7 +181,7 @@ public class OpenInferenceTracing implements AiListenerProvider {
           .map(r -> r.userMessage())
           .map(OpenInferenceCollector::textOf)
           .orElse(null);
-      String guardrailName = event.guardrailClass().getSimpleName();
+      String guardrailName = event.guardrailName();
       traceGuardrail(event, "INPUT", inputMessage, guardrailName);
     }
   }
@@ -195,7 +195,7 @@ public class OpenInferenceTracing implements AiListenerProvider {
           .map(r -> r.aiMessage())
           .map(OpenInferenceCollector::resolveContent)
           .orElse(null);
-      String guardrailName = event.guardrailClass().getSimpleName();
+      String guardrailName = event.guardrailName();
       traceGuardrail(event, "OUTPUT", outputMessage, guardrailName);
     }
   }


### PR DESCRIPTION
- Adapt guardrail to use guardrailName: https://github.com/langchain4j/langchain4j/pull/4940
- Drop Netty HTTP client: https://github.com/langchain4j/langchain4j/pull/5355
- Update tests