### PR TITLE
fix: skip JSON schema format for Ollama when tools are present

### DIFF
--- a/models/smart-workflow-ollama/src/com/axonivy/utils/smart/workflow/model/ollama/OllamaModelProvider.java
+++ b/models/smart-workflow-ollama/src/com/axonivy/utils/smart/workflow/model/ollama/OllamaModelProvider.java
@@ -22,7 +22,7 @@ public class OllamaModelProvider implements ChatModelProvider {
   @Override
   public ChatModel setup(ModelOptions options) {
     var builder = OllamaServiceConnector.buildChatModel(options.modelName());
-    if (options.structuredOutput()) {
+    if (options.structuredOutput() && !options.hasTools()) {
       builder.supportedCapabilities(Capability.RESPONSE_FORMAT_JSON_SCHEMA);
     }
     builder.listeners(options.listeners());

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/TestChatModelFactory.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/TestChatModelFactory.java
@@ -45,7 +45,7 @@ class TestChatModelFactory {
 
   @Test
   void chat() {
-    ChatModel model = loadDummy().setup(new ModelOptions(GENIOUS, true, List.of()));
+    ChatModel model = loadDummy().setup(new ModelOptions(GENIOUS, true, false, List.of()));
     assertThat(model.chat("are you smart?"))
         .isEqualTo("Hey I'm Genious. My Smartness is under development.");
   }
@@ -53,10 +53,10 @@ class TestChatModelFactory {
   @Test
   void capabilities() {
     var provider = loadDummy();
-    ChatModel normal = provider.setup(new ModelOptions(GENIOUS, false, List.of()));
+    ChatModel normal = provider.setup(new ModelOptions(GENIOUS, false, false, List.of()));
     assertThat(normal.supportedCapabilities()).isEmpty();
 
-    ChatModel structured = provider.setup(new ModelOptions(GENIOUS, true, List.of()));
+    ChatModel structured = provider.setup(new ModelOptions(GENIOUS, true, false, List.of()));
     assertThat(structured.supportedCapabilities())
         .contains(Capability.RESPONSE_FORMAT_JSON_SCHEMA);
   }
@@ -74,7 +74,7 @@ class TestChatModelFactory {
         calls.add("response");
       }
     };
-    ChatModel model = loadDummy().setup(new ModelOptions(GENIOUS, false, List.of(listener)));
+    ChatModel model = loadDummy().setup(new ModelOptions(GENIOUS, false, false, List.of(listener)));
     model.chat(ChatRequest.builder().messages(UserMessage.from("ping")).build());
     assertThat(calls).containsExactly("request", "response");
   }

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/TestChatModelProviders.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/TestChatModelProviders.java
@@ -39,7 +39,7 @@ class TestChatModelProviders {
   @MethodSource("providerNames")
   void observable_sharesModelAsRequestParameter(String providerName) {
     var provider = ChatModelFactory.create(providerName).orElseThrow();
-    var model = provider.setup(new ModelOptions("AwesomeModel", true, List.of()));
+    var model = provider.setup(new ModelOptions("AwesomeModel", true, false, List.of()));
     assertThat(model.defaultRequestParameters().modelName())
         .as("Model as request parameter; allows tracing distribution for provider " + providerName)
         .isEqualTo("AwesomeModel");
@@ -60,7 +60,7 @@ class TestChatModelProviders {
         System.out.println("response");
       }
     };
-    var model = provider.setup(new ModelOptions("", true, List.of(myListener)));
+    var model = provider.setup(new ModelOptions("", true, false, List.of(myListener)));
     assertThat(model.listeners())
         .as("providers install listeners passed from Agent")
         .contains(myListener);

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/anthropic/TestAnthropicLoader.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/anthropic/TestAnthropicLoader.java
@@ -50,7 +50,7 @@ public class TestAnthropicLoader {
 
   @Test
   void capabilities() {
-    ChatModel structured = provider.setup(new ModelOptions(MODEL, true, List.of()));
+    ChatModel structured = provider.setup(new ModelOptions(MODEL, true, false, List.of()));
     assertThat(structured.supportedCapabilities()).contains(Capability.RESPONSE_FORMAT_JSON_SCHEMA);
   }
 

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/azureopenai/TestAzureOpenAiLoader.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/azureopenai/TestAzureOpenAiLoader.java
@@ -63,10 +63,10 @@ public class TestAzureOpenAiLoader {
 
   @Test
   void capabilities() {
-    ChatModel normal = provider.setup(new ModelOptions(TEST_DEPLOYMENT_NAME, false, List.of()));
+    ChatModel normal = provider.setup(new ModelOptions(TEST_DEPLOYMENT_NAME, false, false, List.of()));
     assertThat(normal.supportedCapabilities()).isEmpty();
 
-    ChatModel structured = provider.setup(new ModelOptions(TEST_DEPLOYMENT_NAME, true, List.of()));
+    ChatModel structured = provider.setup(new ModelOptions(TEST_DEPLOYMENT_NAME, true, false, List.of()));
     assertThat(structured.supportedCapabilities()).contains(Capability.RESPONSE_FORMAT_JSON_SCHEMA);
   }
 
@@ -83,7 +83,7 @@ public class TestAzureOpenAiLoader {
   @Test
   void temperature_gpt4(AppFixture fixture) {
     fixture.var(DEPLOYMENTS_PREFIX + "." + TEST_DEPLOYMENT_NAME + ".Model", "gpt-4.1-mini");
-    var model = provider.setup(new ModelOptions(TEST_DEPLOYMENT_NAME, false, List.of()));
+    var model = provider.setup(new ModelOptions(TEST_DEPLOYMENT_NAME, false, false, List.of()));
     assertThat(model.defaultRequestParameters().temperature())
         .isEqualTo(0.0);
   }
@@ -91,7 +91,7 @@ public class TestAzureOpenAiLoader {
   @Test
   void temperature_gpt5(AppFixture fixture) {
     fixture.var(DEPLOYMENTS_PREFIX + "." + TEST_DEPLOYMENT_NAME + ".Model", "gpt-5");
-    var model = provider.setup(new ModelOptions(TEST_DEPLOYMENT_NAME, false, List.of()));
+    var model = provider.setup(new ModelOptions(TEST_DEPLOYMENT_NAME, false, false, List.of()));
     assertThat(model.defaultRequestParameters().temperature())
         .isEqualTo(1.0);
   }
@@ -99,7 +99,7 @@ public class TestAzureOpenAiLoader {
   @Test
   void temperature_gpt5_nano(AppFixture fixture) {
     fixture.var(DEPLOYMENTS_PREFIX + "." + TEST_DEPLOYMENT_NAME + ".Model", "gpt-5-nano");
-    var model = provider.setup(new ModelOptions(TEST_DEPLOYMENT_NAME, false, List.of()));
+    var model = provider.setup(new ModelOptions(TEST_DEPLOYMENT_NAME, false, false, List.of()));
     assertThat(model.defaultRequestParameters().temperature())
         .isEqualTo(1.0);
   }

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/gemini/TestGeminiLoader.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/gemini/TestGeminiLoader.java
@@ -57,10 +57,10 @@ public class TestGeminiLoader {
 
   @Test
   void capabilities() {
-    ChatModel normal = provider.setup(new ModelOptions(MODEL, false, List.of()));
+    ChatModel normal = provider.setup(new ModelOptions(MODEL, false, false, List.of()));
     assertThat(normal.supportedCapabilities()).isEmpty();
 
-    ChatModel structured = provider.setup(new ModelOptions(MODEL, true, List.of()));
+    ChatModel structured = provider.setup(new ModelOptions(MODEL, true, false, List.of()));
     assertThat(structured.supportedCapabilities().isEmpty());
   }
 

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/ollama/TestOllamaLoader.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/ollama/TestOllamaLoader.java
@@ -48,15 +48,22 @@ public class TestOllamaLoader {
 
   @Test
   void modelNameIsPassedAsRequestParameter() {
-    ChatModel model = provider.setup(new ModelOptions(MODEL, false, List.of()));
+    ChatModel model = provider.setup(new ModelOptions(MODEL, false, false, List.of()));
     assertThat(model.defaultRequestParameters().modelName()).isEqualTo(MODEL);
   }
 
   @Test
   void structuredOutputIsAdvertisedAsSupported() {
-    ChatModel model = provider.setup(new ModelOptions(MODEL, true, List.of()));
+    ChatModel model = provider.setup(new ModelOptions(MODEL, true, false, List.of()));
     assertThat(model.supportedCapabilities())
         .contains(Capability.RESPONSE_FORMAT_JSON_SCHEMA);
+  }
+
+  @Test
+  void structuredOutputWithToolsDoesNotConstrainJsonSchema() {
+    ChatModel model = provider.setup(new ModelOptions(MODEL, true, true, List.of()));
+    assertThat(model.supportedCapabilities())
+        .doesNotContain(Capability.RESPONSE_FORMAT_JSON_SCHEMA);
   }
 
   @Test

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/xai/TestXAiLoader.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/xai/TestXAiLoader.java
@@ -53,7 +53,7 @@ public class TestXAiLoader {
 
   @Test
   void capabilities() {
-    ChatModel structured = provider.setup(new ModelOptions(MODEL, true, List.of()));
+    ChatModel structured = provider.setup(new ModelOptions(MODEL, true, false, List.of()));
     assertThat(structured.supportedCapabilities()).contains(Capability.RESPONSE_FORMAT_JSON_SCHEMA);
   }
 

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/model/spi/ChatModelProvider.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/model/spi/ChatModelProvider.java
@@ -17,10 +17,11 @@ public interface ChatModelProvider {
   public static record ModelOptions(
       String modelName,
       boolean structuredOutput,
+      boolean hasTools,
       List<ChatModelListener> listeners) {
 
     public ModelOptions() {
-      this(null, false, List.of());
+      this(null, false, false, List.of());
     }
 
     public static ModelOptions options() {
@@ -28,15 +29,19 @@ public interface ChatModelProvider {
     }
 
     public ModelOptions structuredOutput(boolean structured) {
-      return new ModelOptions(modelName, structured, listeners);
+      return new ModelOptions(modelName, structured, hasTools, listeners);
+    }
+
+    public ModelOptions hasTools(boolean tools) {
+      return new ModelOptions(modelName, structuredOutput, tools, listeners);
     }
 
     public ModelOptions modelName(String name) {
-      return new ModelOptions(name, structuredOutput, listeners);
+      return new ModelOptions(name, structuredOutput, hasTools, listeners);
     }
 
     public ModelOptions listeners(List<ChatModelListener> chatListeners) {
-      return new ModelOptions(modelName, structuredOutput, chatListeners);
+      return new ModelOptions(modelName, structuredOutput, hasTools, chatListeners);
     }
   }
 

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/program/internal/AgentCallExecutor.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/program/internal/AgentCallExecutor.java
@@ -74,8 +74,9 @@ public class AgentCallExecutor {
     var agentBuilder = AiServices.builder(agentType);
     var memory = configureMemory(agentBuilder);
     var human = configureHumanInTheLoop(memory, agentBuilder);
-    configureModel(agentBuilder, structured.isPresent());
-    configureToolProvider(agentBuilder);
+    var toolFilter = executeListOfStrings(Conf.TOOLS).orElse(null);
+    configureModel(agentBuilder, structured.isPresent(), toolFilter);
+    configureToolProvider(agentBuilder, toolFilter);
     configureGuardrails(agentBuilder);
     configureSystemMessage(human, agentBuilder);
     var agent = agentBuilder.build();
@@ -144,13 +145,14 @@ public class AgentCallExecutor {
     return humanInTheLoop;
   }
 
-  private void configureModel(AiServices<? extends DynamicAgent<?>> agentBuilder, boolean structured) {
+  private void configureModel(AiServices<? extends DynamicAgent<?>> agentBuilder, boolean structured, List<String> toolFilter) {
     var providerName = execute(Conf.PROVIDER, String.class).orElse(StringUtils.EMPTY);
     var model = execute(Conf.MODEL, String.class).orElse(StringUtils.EMPTY);
     var provider = ChatModelFactory.getProviderOrDefault(providerName);
     var modelOptions = options()
         .modelName(model)
-        .structuredOutput(structured);
+        .structuredOutput(structured)
+        .hasTools(toolFilter != null && !toolFilter.isEmpty());
     var chatModel = provider.setup(modelOptions);
     agentBuilder.chatModel(chatModel);
     var modelName = chatModel.defaultRequestParameters().modelName();
@@ -158,8 +160,7 @@ public class AgentCallExecutor {
       .forEach(agentBuilder::registerListener);
   }
 
-  private void configureToolProvider(AiServices<? extends DynamicAgent<?>> agentBuilder) {
-    List<String> toolFilter = executeListOfStrings(Conf.TOOLS).orElse(null);
+  private void configureToolProvider(AiServices<? extends DynamicAgent<?>> agentBuilder, List<String> toolFilter) {
     ToolProvider ivyTools = new IvySubProcessToolsProvider().filtering(toolFilter);
     agentBuilder.toolProvider(request -> {
       List<AiServiceTool> all = new ArrayList<>(ivyTools.provideTools(request).aiServiceTools());


### PR DESCRIPTION
- Ollama does not support `format: {json_schema}` and `tools` in the same request.
- Fix current Ollama E2E test failing because model cannot pickup `tool`.