### PR TITLE
SpiLoader.load() returns duplicate provider instances when multiple PMVs share the same SPI registration

### DIFF
--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/spi/internal/TestSpiLoader.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/spi/internal/TestSpiLoader.java
@@ -35,7 +35,7 @@ class TestSpiLoader {
     var loader = new SpiLoader(pmv) {
       @Override
       protected Stream<IProcessModelVersion> pmvsInScope() {
-        return Stream.of(pmv, pmv); // same PMV twice simulates duplicate dependency declarations
+        return Stream.of(pmv, pmv);
       }
     };
     var impls = loader.load(ChatModelProvider.class);

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/spi/internal/TestSpiLoader.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/model/spi/internal/TestSpiLoader.java
@@ -2,6 +2,8 @@ package com.axonivy.utils.smart.workflow.model.spi.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
 
 import com.axonivy.utils.smart.workflow.model.dummy.DummyChatModelProvider;
@@ -25,6 +27,24 @@ class TestSpiLoader {
     assertThat(dummies)
         .as("SPI loader finds imlementors")
         .isNotEmpty();
+  }
+
+  @Test
+  void load_noDuplicates_samePmvTwice() {
+    var pmv = IProcessModelVersion.current();
+    var loader = new SpiLoader(pmv) {
+      @Override
+      protected Stream<IProcessModelVersion> pmvsInScope() {
+        return Stream.of(pmv, pmv); // same PMV twice simulates duplicate dependency declarations
+      }
+    };
+    var impls = loader.load(ChatModelProvider.class);
+    var classNames = impls.stream()
+        .map(impl -> impl.getClass().getName())
+        .toList();
+    assertThat(classNames)
+        .as("each provider class must appear only once even if the same PMV is in scope multiple times")
+        .doesNotHaveDuplicates();
   }
 
 }

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiLoader.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiLoader.java
@@ -2,7 +2,6 @@ package com.axonivy.utils.smart.workflow.spi.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
@@ -64,7 +63,7 @@ public class SpiLoader {
       @SuppressWarnings("unchecked")
       var instance = (T) loaded.getConstructor().newInstance();
       return Optional.of(instance);
-    } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ex) {
+    } catch (Exception ex) {
       return Optional.empty();
     }
   }
@@ -80,7 +79,7 @@ public class SpiLoader {
         var what = read(in);
         implRefs.add(what);
       }
-    } catch (IOException ex) {
+    } catch (Exception ex) {
 
     }
     return implRefs;

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiLoader.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiLoader.java
@@ -28,11 +28,16 @@ public class SpiLoader {
     return pmvsInScope()
         .flatMap(p -> findImpl(p, type).stream())
         .filter(type::isInstance)
-        .distinct()
+        .collect(Collectors.toMap(
+            impl -> impl.getClass().getName(),
+            impl -> impl,
+            (existing, duplicate) -> existing))
+        .values()
+        .stream()
         .collect(Collectors.toSet());
   }
 
-  private Stream<IProcessModelVersion> pmvsInScope() {
+  protected Stream<IProcessModelVersion> pmvsInScope() {
     return Stream.concat(Stream.of(pmv), pmv.getAllDependentProcessModelVersions());
   }
 

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiLoader.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiLoader.java
@@ -6,11 +6,12 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import ch.ivyteam.ivy.application.IProcessModelVersion;
@@ -26,16 +27,15 @@ public class SpiLoader {
   }
 
   public <T> Set<T> load(Class<T> type) {
-    return pmvsInScope()
-        .flatMap(p -> findImpl(p, type).stream())
-        .filter(type::isInstance)
-        .collect(Collectors.toMap(
-            impl -> impl.getClass().getName(),
-            impl -> impl,
-            (existing, duplicate) -> existing))
-        .values()
-        .stream()
-        .collect(Collectors.toSet());
+    Map<String, T> seen = new HashMap<>();
+    List<T> implementations = pmvsInScope()
+      .flatMap(p -> findImpl(p, type).stream())
+      .filter(type::isInstance)
+      .toList();
+    for (T impl : implementations) {
+      seen.putIfAbsent(impl.getClass().getName(), impl);
+    }
+    return new HashSet<>(seen.values());
   }
 
   protected Stream<IProcessModelVersion> pmvsInScope() {

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiLoader.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/spi/internal/SpiLoader.java
@@ -2,6 +2,7 @@ package com.axonivy.utils.smart.workflow.spi.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
@@ -63,7 +64,7 @@ public class SpiLoader {
       @SuppressWarnings("unchecked")
       var instance = (T) loaded.getConstructor().newInstance();
       return Optional.of(instance);
-    } catch (Exception ex) {
+    } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException ex) {
       return Optional.empty();
     }
   }
@@ -79,7 +80,7 @@ public class SpiLoader {
         var what = read(in);
         implRefs.add(what);
       }
-    } catch (Exception ex) {
+    } catch (IOException ex) {
 
     }
     return implRefs;


### PR DESCRIPTION
### Root cause

`pmvsInScope()` iterates the main PMV plus all dependent PMVs. For each PMV, `findImpl()` instantiates providers via reflection (newInstance()), producing distinct objects per call. The previous deduplication used distinct() and HashSet, both of which rely on object identity — so two instances of the same class were treated as different elements.

### Fix

Replace distinct() + Collectors.toSet() with  a manual HashMap + putIfAbsent loop.
This ensures each provider class appears exactly once regardless of how many PMVs declare it.

### How to reproduce

- revert code of `SpiLoader`
- Run the new test case `TestSpiLoader.load_noDuplicates_samePmvTwice`, you will see duplication error.

### Bonus

reduce VS Code warnings in `SpiLoader`

<img width="1032" height="740" alt="image" src="https://github.com/user-attachments/assets/afb6ae50-145d-4557-9cd2-46bdd567bddc" />


