### PR TITLE
refactor: adapt new process-extension-api

### DIFF
--- a/smart-workflow/pom.xml
+++ b/smart-workflow/pom.xml
@@ -22,8 +22,8 @@
       <artifactId>ivy-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.axonivy.ivy.spi</groupId>
-      <artifactId>ivy-process-extension-spi</artifactId>
+      <groupId>com.axonivy.ivy.api.extension</groupId>
+      <artifactId>ivy-process-extension-api</artifactId>
     </dependency>
     <dependency>
       <groupId>dev.langchain4j</groupId>


### PR DESCRIPTION
we deprecated most classes of the previous approach: and crafted a new jar.
the new artifact has the benefit of not even containing most of the new deprecated APIs. So things become clearer.