### PR TITLE
Switch to Jakarta Sprint.29 artifacts

### DIFF
--- a/demo/smart-workflow-supplier-demo-test/pom.xml
+++ b/demo/smart-workflow-supplier-demo-test/pom.xml
@@ -79,6 +79,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
+        <version>${project.parent.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/demo/smart-workflow-supplier-demo-test/pom.xml
+++ b/demo/smart-workflow-supplier-demo-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
     <artifactId>ivy-project-parent</artifactId>
-    <version>14.0.0-jakarta-SNAPSHOT</version>
+    <version>14.0.0-m29</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.axonivy.utils.ai</groupId>

--- a/demo/smart-workflow-supplier-demo/pom.xml
+++ b/demo/smart-workflow-supplier-demo/pom.xml
@@ -62,6 +62,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
+        <version>${project.parent.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/demo/smart-workflow-supplier-demo/pom.xml
+++ b/demo/smart-workflow-supplier-demo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
     <artifactId>ivy-project-parent</artifactId>
-    <version>14.0.0-jakarta-SNAPSHOT</version>
+    <version>14.0.0-m29</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.axonivy.utils.ai</groupId>

--- a/models/smart-workflow-anthropic/pom.xml
+++ b/models/smart-workflow-anthropic/pom.xml
@@ -71,6 +71,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
+        <version>${project.parent.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/models/smart-workflow-anthropic/pom.xml
+++ b/models/smart-workflow-anthropic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
     <artifactId>ivy-project-parent</artifactId>
-    <version>14.0.0-jakarta-SNAPSHOT</version>
+    <version>14.0.0-m29</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.axonivy.utils.ai</groupId>

--- a/models/smart-workflow-azure-openai/pom.xml
+++ b/models/smart-workflow-azure-openai/pom.xml
@@ -79,6 +79,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
+        <version>${project.parent.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/models/smart-workflow-azure-openai/pom.xml
+++ b/models/smart-workflow-azure-openai/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
     <artifactId>ivy-project-parent</artifactId>
-    <version>14.0.0-jakarta-SNAPSHOT</version>
+    <version>14.0.0-m29</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.axonivy.utils.ai</groupId>

--- a/models/smart-workflow-gemini/pom.xml
+++ b/models/smart-workflow-gemini/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
     <artifactId>ivy-project-parent</artifactId>
-    <version>14.0.0-jakarta-SNAPSHOT</version>
+    <version>14.0.0-m29</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.axonivy.utils.ai</groupId>

--- a/models/smart-workflow-gemini/pom.xml
+++ b/models/smart-workflow-gemini/pom.xml
@@ -75,6 +75,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
+        <version>${project.parent.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/models/smart-workflow-ollama/pom.xml
+++ b/models/smart-workflow-ollama/pom.xml
@@ -71,6 +71,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
+        <version>${project.parent.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/models/smart-workflow-ollama/pom.xml
+++ b/models/smart-workflow-ollama/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
     <artifactId>ivy-project-parent</artifactId>
-    <version>14.0.0-jakarta-SNAPSHOT</version>
+    <version>14.0.0-m29</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.axonivy.utils.ai</groupId>

--- a/models/smart-workflow-openai/pom.xml
+++ b/models/smart-workflow-openai/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
     <artifactId>ivy-project-parent</artifactId>
-    <version>14.0.0-jakarta-SNAPSHOT</version>
+    <version>14.0.0-m29</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.axonivy.utils.ai</groupId>

--- a/models/smart-workflow-openai/pom.xml
+++ b/models/smart-workflow-openai/pom.xml
@@ -68,6 +68,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
+        <version>${project.parent.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/models/smart-workflow-xai/pom.xml
+++ b/models/smart-workflow-xai/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
     <artifactId>ivy-project-parent</artifactId>
-    <version>14.0.0-jakarta-SNAPSHOT</version>
+    <version>14.0.0-m29</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.axonivy.utils.ai</groupId>

--- a/models/smart-workflow-xai/pom.xml
+++ b/models/smart-workflow-xai/pom.xml
@@ -68,6 +68,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
+        <version>${project.parent.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/rag/smart-workflow-opensearch-rag/pom.xml
+++ b/rag/smart-workflow-opensearch-rag/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
     <artifactId>ivy-project-parent</artifactId>
-    <version>14.0.0-jakarta-SNAPSHOT</version>
+    <version>14.0.0-m29</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.axonivy.utils.ai</groupId>

--- a/rag/smart-workflow-opensearch-rag/pom.xml
+++ b/rag/smart-workflow-opensearch-rag/pom.xml
@@ -45,6 +45,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
+        <version>${project.parent.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/smart-workflow-demo/pom.xml
+++ b/smart-workflow-demo/pom.xml
@@ -62,6 +62,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
+        <version>${project.parent.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/smart-workflow-demo/pom.xml
+++ b/smart-workflow-demo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
     <artifactId>ivy-project-parent</artifactId>
-    <version>14.0.0-jakarta-SNAPSHOT</version>
+    <version>14.0.0-m29</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.axonivy.utils.ai</groupId>

--- a/smart-workflow-test/pom.xml
+++ b/smart-workflow-test/pom.xml
@@ -131,6 +131,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
+        <version>${project.parent.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/smart-workflow-test/pom.xml
+++ b/smart-workflow-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
     <artifactId>ivy-project-parent</artifactId>
-    <version>14.0.0-jakarta-SNAPSHOT</version>
+    <version>14.0.0-m29</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.axonivy.utils.ai</groupId>

--- a/smart-workflow-webtest/pom.xml
+++ b/smart-workflow-webtest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
     <artifactId>ivy-project-parent</artifactId>
-    <version>14.0.0-jakarta-SNAPSHOT</version>
+    <version>14.0.0-m29</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.axonivy.utils.ai</groupId>

--- a/smart-workflow-webtest/pom.xml
+++ b/smart-workflow-webtest/pom.xml
@@ -83,6 +83,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
+        <version>${project.parent.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/smart-workflow/pom.xml
+++ b/smart-workflow/pom.xml
@@ -127,6 +127,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
+        <version>${project.parent.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/smart-workflow/pom.xml
+++ b/smart-workflow/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.axonivy.ivy.api</groupId>
     <artifactId>ivy-project-parent</artifactId>
-    <version>14.0.0-jakarta-SNAPSHOT</version>
+    <version>14.0.0-m29</version>
     <relativePath></relativePath>
   </parent>
   <groupId>com.axonivy.utils.ai</groupId>


### PR DESCRIPTION
let's go to a defined sprint release version:
- we are able to do an official first beta version release, that supports jakarta
- the ivy dev baseline is right now adopting breaking changes in IProcessModelVersion which we are depending on.