### PR TITLE
Added inputVersion param as input to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   schedule:
     - cron:  '21 21 * * *'
   workflow_dispatch:
+    inputs:
+      ivyVersion:
+        type: string
+        required: false
+        default: dev
+        description: ivy engine permalink (e.g. sprint, nightly, dev)
 
 permissions:
   actions: read
@@ -19,7 +25,7 @@ jobs:
     with:
       javaVersion: 25
       cspellExtraWords: .github/cspell-extra-words.txt
-      ivyVersion: sprint
+      ivyVersion: ${{ inputs.ivyVersion || 'dev' }}
     secrets:
       mvnArgs: |
        | sed -E "s|[0-9]. (WARNING) in ([^ ]*) \(at line ([0-9]+)\)(.*)|::\L\1 file=\2,line=\3::build issue\n\2@\3\4|g"\

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       javaVersion: 25
       cspellExtraWords: .github/cspell-extra-words.txt
+      ivyVersion: sprint
     secrets:
       mvnArgs: |
        | sed -E "s|[0-9]. (WARNING) in ([^ ]*) \(at line ([0-9]+)\)(.*)|::\L\1 file=\2,line=\3::build issue\n\2@\3\4|g"\

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,6 +5,12 @@ on:
   schedule:
     - cron:  '21 21 * * *'
   workflow_dispatch:
+    inputs:
+      ivyVersion:
+        type: string
+        required: false
+        default: dev
+        description: ivy engine permalink (e.g. sprint, nightly, dev)
 
 permissions:
   contents: read
@@ -16,4 +22,4 @@ jobs:
     uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v6
     with:
       targetBranchForBuildFromMaster: master
-      ivyVersion: sprint
+      ivyVersion: ${{ inputs.ivyVersion || 'dev' }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,3 +16,4 @@ jobs:
     uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v6
     with:
       targetBranchForBuildFromMaster: master
+      ivyVersion: sprint

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,7 @@ jobs:
       mvnArgs: -P e2e.test -Dproviders=${{ inputs.providers }}
       javaVersion: 25
       cspellExtraWords: .github/cspell-extra-words.txt
+      ivyVersion: sprint
     secrets:
       mvnArgs: |
         -DOPEN_AI_API_KEY=${{ secrets.OPEN_AI_API_KEY }} \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,11 @@ on:
         description: 'Comma-separated provider names to run E2E for. Empty = all. E.g. "OpenAI,Ollama"'
         required: false
         default: ''
+      ivyVersion:
+        type: string
+        required: false
+        default: dev
+        description: ivy engine permalink (e.g. sprint, nightly, dev)
 
 permissions:
   contents: read
@@ -21,7 +26,7 @@ jobs:
       mvnArgs: -P e2e.test -Dproviders=${{ inputs.providers }}
       javaVersion: 25
       cspellExtraWords: .github/cspell-extra-words.txt
-      ivyVersion: sprint
+      ivyVersion: ${{ inputs.ivyVersion || 'dev' }}
     secrets:
       mvnArgs: |
         -DOPEN_AI_API_KEY=${{ secrets.OPEN_AI_API_KEY }} \

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '0 1 * * *' # 1 AM every night
   workflow_dispatch:
+    inputs:
+      ivyVersion:
+        type: string
+        required: false
+        default: dev
+        description: ivy engine permalink (e.g. sprint, nightly, dev)
 
 permissions:
   contents: read
@@ -16,4 +22,4 @@ jobs:
       mvnArgs: -P container.test
       javaVersion: 25
       cspellExtraWords: .github/cspell-extra-words.txt
-      ivyVersion: sprint
+      ivyVersion: ${{ inputs.ivyVersion || 'dev' }}

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -16,3 +16,4 @@ jobs:
       mvnArgs: -P container.test
       javaVersion: 25
       cspellExtraWords: .github/cspell-extra-words.txt
+      ivyVersion: sprint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
         required: true
         default: 14.0.0-b1
         description: the release to introduce (e.g. b1/b2)
+      ivyVersion:
+        type: string
+        required: false
+        default: dev
+        description: ivy engine permalink (e.g. sprint, nightly, dev)
 
 permissions:
   contents: write
@@ -18,5 +23,5 @@ jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/release.yml@v6
     with:
-      mvnArgs: -DignoreSnapshots=true -DreleaseVersion=${{ inputs.releaseVersion }}
+      mvnArgs: -DignoreSnapshots=true -DreleaseVersion=${{ inputs.releaseVersion }} -Divy.engine.download.url=https://dev.axonivy.com/permalink/${{ inputs.ivyVersion }}/axonivy-engine.zip
       javaVersion: 25


### PR DESCRIPTION
Allow overriding ivy engine version via workflow dispatch inputs

<img width="447" height="423" alt="image" src="https://github.com/user-attachments/assets/2be43d12-a9ac-4f80-842f-17b44340e927" />

Adds an optional ivyVersion input to:
- dev
- ci
- e2e
- it
- release

workflows so the ivy engine permalink (e.g. dev, sprint, nightly) can be selected at dispatch time.

Defaults to `dev` to align with the upstream reusable workflow defaults.