### PR TITLE
Migrate all smart-workflow projects to new extension.api

### DIFF
--- a/demo/smart-workflow-supplier-demo/pom.xml
+++ b/demo/smart-workflow-supplier-demo/pom.xml
@@ -17,8 +17,8 @@
       <artifactId>ivy-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.axonivy.ivy.spi</groupId>
-      <artifactId>ivy-process-extension-spi</artifactId>
+      <groupId>com.axonivy.ivy.api.extension</groupId>
+      <artifactId>ivy-process-extension-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/smart-workflow-demo/pom.xml
+++ b/smart-workflow-demo/pom.xml
@@ -17,8 +17,8 @@
       <artifactId>ivy-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.axonivy.ivy.spi</groupId>
-      <artifactId>ivy-process-extension-spi</artifactId>
+      <groupId>com.axonivy.ivy.api.extension</groupId>
+      <artifactId>ivy-process-extension-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/smart-workflow-test/pom.xml
+++ b/smart-workflow-test/pom.xml
@@ -17,8 +17,8 @@
       <artifactId>ivy-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.axonivy.ivy.spi</groupId>
-      <artifactId>ivy-process-extension-spi</artifactId>
+      <groupId>com.axonivy.ivy.api.extension</groupId>
+      <artifactId>ivy-process-extension-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
without these dependencies the validation fails. seems to be a false-positive though, since the provided dep from the referenced 'smart-workflow:iar' should be considered.

<img width="1686" height="847" alt="~-dev-market-smart-workflow-2_001" src="https://github.com/user-attachments/assets/f9a73fe8-18c8-41db-bd81-837d7099c74a" />

[mvn.log.txt](https://github.com/user-attachments/files/30544993/mvn.log.txt)

