### PR TITLE
AIAI-598: Guardrail throws error when user message has file content

### DIFF
--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/governance/history/TestInputGuardrailListener.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/governance/history/TestInputGuardrailListener.java
@@ -16,6 +16,8 @@ import com.axonivy.utils.smart.workflow.guardrails.adapter.InputGuardrailAdapter
 import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailResult;
 import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowInputGuardrail;
 
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.guardrail.GuardrailRequestParams;
 import dev.langchain4j.guardrail.InputGuardrail;
@@ -81,6 +83,18 @@ public class TestInputGuardrailListener {
     assertThat(entry.failureMessage()).isEqualTo("Critical violation");
   }
 
+  @Test
+  void recordsMultimodalUserMessage_regressionForSingleTextBug() {
+    var multimodal = UserMessage.from(
+        TextContent.from("describe this:"),
+        ImageContent.from("http://example.com/img.png", "image/png"));
+
+    listener.onEvent(buildEvent(multimodal, InputGuardrailResult.success(), Duration.ofMillis(10)));
+
+    assertThat(captured).hasSize(1);
+    assertThat(captured.get(0).message()).isEqualTo("describe this:\n<file: IMAGE>");
+  }
+
   private static final InputGuardrail GUARDRAIL_HELPER = new InputGuardrail() {};
   private static final InputGuardrailAdapter INPUT_ADAPTER = new InputGuardrailAdapter(new TestInputGuardrail());
 
@@ -92,6 +106,10 @@ public class TestInputGuardrailListener {
   }
 
   private InputGuardrailExecutedEvent buildEvent(String userText, InputGuardrailResult result, Duration duration) {
+    return buildEvent(UserMessage.from(userText), result, duration);
+  }
+
+  private InputGuardrailExecutedEvent buildEvent(UserMessage userMessage, InputGuardrailResult result, Duration duration) {
     var invocationCtx = InvocationContext.builder()
         .invocationId(UUID.randomUUID())
         .timestamp(Instant.now())
@@ -99,7 +117,7 @@ public class TestInputGuardrailListener {
         .interfaceName("ChatAgent")
         .build();
     var request = InputGuardrailRequest.builder()
-        .userMessage(UserMessage.from(userText))
+        .userMessage(userMessage)
         .commonParams(GuardrailRequestParams.builder()
             .userMessageTemplate("")
             .variables(java.util.Map.of())

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestGuardrailInspectionText.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestGuardrailInspectionText.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailInspectionText;
+import com.axonivy.utils.smart.workflow.guardrails.adapter.GuardrailInspectionText;
 
 import dev.langchain4j.data.message.AudioContent;
 import dev.langchain4j.data.message.Content;

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestGuardrailInspectionText.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestGuardrailInspectionText.java
@@ -1,0 +1,68 @@
+package com.axonivy.utils.smart.workflow.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailInspectionText;
+
+import dev.langchain4j.data.message.AudioContent;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.PdfFileContent;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.data.message.VideoContent;
+
+class TestGuardrailInspectionText {
+
+  @Test
+  void returnsEmptyForNullMessage() {
+    assertThat(GuardrailInspectionText.text(null)).isEmpty();
+  }
+
+  @Test
+  void returnsTextAsIsForTextOnlyMessage() {
+    var message = UserMessage.from(TextContent.from("What is the weather?"));
+
+    assertThat(GuardrailInspectionText.text(message)).isEqualTo("What is the weather?");
+  }
+
+  @Test
+  void joinsMultipleTextPartsWithNewline() {
+    var message = UserMessage.from(TextContent.from("first"), TextContent.from("second"));
+
+    assertThat(GuardrailInspectionText.text(message)).isEqualTo("first\nsecond");
+  }
+
+  @Test
+  void doesNotThrowOnMultimodalMessage_regressionForSingleTextBug() {
+    var message = UserMessage.from(
+        TextContent.from("describe this:"),
+        ImageContent.from("http://example.com/img.png", "image/png"));
+
+    assertThat(GuardrailInspectionText.text(message)).isEqualTo("describe this:\n<file: IMAGE>");
+  }
+
+  @ParameterizedTest
+  @MethodSource("filePlaceholders")
+  void replacesFileContentWithPlaceholder(FilePlaceholderCase testCase) {
+    var message = UserMessage.from(testCase.content());
+
+    assertThat(GuardrailInspectionText.text(message)).isEqualTo("<file: " + testCase.expectedType() + ">");
+  }
+
+  record FilePlaceholderCase(Content content, String expectedType) {}
+
+  static Stream<FilePlaceholderCase> filePlaceholders() {
+    return Stream.of(
+        new FilePlaceholderCase(ImageContent.from("http://example.com/img.png", "image/png"), "IMAGE"),
+        new FilePlaceholderCase(PdfFileContent.from("http://example.com/doc.pdf", "application/pdf"), "PDF"),
+        new FilePlaceholderCase(AudioContent.from("http://example.com/clip.mp3", "audio/mp3"), "AUDIO"),
+        new FilePlaceholderCase(VideoContent.from("http://example.com/clip.mp4", "video/mp4"), "VIDEO"));
+  }
+}

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestInputGuardrailAdapter.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestInputGuardrailAdapter.java
@@ -24,34 +24,28 @@ import dev.langchain4j.invocation.InvocationContext;
 
 class TestInputGuardrailAdapter {
 
-  @Test
-  void validateUserMessage_allowsSafeInput() {
-    var adapter = new InputGuardrailAdapter(message -> GuardrailResult.allow());
-
-    var result = adapter.validate(UserMessage.from(TextContent.from("hello")));
-
-    assertThat(result.result()).isEqualTo(Result.SUCCESS);
-  }
+  record Case(GuardrailResult delegateResult, Result expectedResult, String expectedSuccessfulText,
+      String expectedFailureMessage) {}
 
   @Test
-  void validateUserMessage_blocksUnsafeInputWithReason() {
-    var adapter = new InputGuardrailAdapter(message -> GuardrailResult.block("blocked reason"));
+  void validateUserMessage_returnsResultsFromDelegate() {
+    var cases = List.of(
+        new Case(GuardrailResult.allow(), Result.SUCCESS, null, null),
+        new Case(GuardrailResult.block("blocked reason"), Result.FAILURE, null, "blocked reason"),
+        new Case(GuardrailResult.allowWithRewrite("rewritten"), Result.SUCCESS_WITH_RESULT, "rewritten", null));
 
-    var result = adapter.validate(UserMessage.from(TextContent.from("bad input")));
+    for (var testCase : cases) {
+      var adapter = new InputGuardrailAdapter(_ -> testCase.delegateResult());
 
-    assertThat(result.result()).isEqualTo(Result.FAILURE);
-    List<Failure> failures = result.failures();
-    assertThat(failures).extracting(Failure::message).containsExactly("blocked reason");
-  }
+      var result = adapter.validate(UserMessage.from(TextContent.from("hello")));
 
-  @Test
-  void validateUserMessage_returnsRewrittenText() {
-    var adapter = new InputGuardrailAdapter(message -> GuardrailResult.allowWithRewrite("rewritten"));
-
-    var result = adapter.validate(UserMessage.from(TextContent.from("original")));
-
-    assertThat(result.result()).isEqualTo(Result.SUCCESS_WITH_RESULT);
-    assertThat(result.successfulText()).isEqualTo("rewritten");
+      assertThat(result.result()).as("case %s", testCase).isEqualTo(testCase.expectedResult());
+      assertThat(result.successfulText()).as("case %s", testCase).isEqualTo(testCase.expectedSuccessfulText());
+      if (testCase.expectedFailureMessage() != null) {
+        List<Failure> failures = result.failures();
+        assertThat(failures).extracting(Failure::message).containsExactly(testCase.expectedFailureMessage());
+      }
+    }
   }
 
   @Test

--- a/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestInputGuardrailAdapter.java
+++ b/smart-workflow-test/src_test/com/axonivy/utils/smart/workflow/guardrails/TestInputGuardrailAdapter.java
@@ -1,0 +1,109 @@
+package com.axonivy.utils.smart.workflow.guardrails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.axonivy.utils.smart.workflow.guardrails.adapter.InputGuardrailAdapter;
+import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailResult;
+import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowInputGuardrail;
+
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.guardrail.GuardrailRequestParams;
+import dev.langchain4j.guardrail.GuardrailResult.Failure;
+import dev.langchain4j.guardrail.GuardrailResult.Result;
+import dev.langchain4j.guardrail.InputGuardrailRequest;
+import dev.langchain4j.invocation.InvocationContext;
+
+class TestInputGuardrailAdapter {
+
+  @Test
+  void validateUserMessage_allowsSafeInput() {
+    var adapter = new InputGuardrailAdapter(message -> GuardrailResult.allow());
+
+    var result = adapter.validate(UserMessage.from(TextContent.from("hello")));
+
+    assertThat(result.result()).isEqualTo(Result.SUCCESS);
+  }
+
+  @Test
+  void validateUserMessage_blocksUnsafeInputWithReason() {
+    var adapter = new InputGuardrailAdapter(message -> GuardrailResult.block("blocked reason"));
+
+    var result = adapter.validate(UserMessage.from(TextContent.from("bad input")));
+
+    assertThat(result.result()).isEqualTo(Result.FAILURE);
+    List<Failure> failures = result.failures();
+    assertThat(failures).extracting(Failure::message).containsExactly("blocked reason");
+  }
+
+  @Test
+  void validateUserMessage_returnsRewrittenText() {
+    var adapter = new InputGuardrailAdapter(message -> GuardrailResult.allowWithRewrite("rewritten"));
+
+    var result = adapter.validate(UserMessage.from(TextContent.from("original")));
+
+    assertThat(result.result()).isEqualTo(Result.SUCCESS_WITH_RESULT);
+    assertThat(result.successfulText()).isEqualTo("rewritten");
+  }
+
+  @Test
+  void validateUserMessage_doesNotThrowOnMultimodalMessage_regressionForSingleTextBug() {
+    String[] capturedMessage = new String[1];
+    var adapter = new InputGuardrailAdapter(message -> {
+      capturedMessage[0] = message;
+      return GuardrailResult.allow();
+    });
+    var multimodal = UserMessage.from(
+        TextContent.from("describe this:"),
+        ImageContent.from("http://example.com/img.png", "image/png"));
+
+    var result = adapter.validate(multimodal);
+
+    assertThat(result.result()).isEqualTo(Result.SUCCESS);
+    assertThat(capturedMessage[0]).isEqualTo("describe this:\n<file: IMAGE>");
+  }
+
+  @Test
+  void validateRequest_passesInvocationIdToDelegate() {
+    UUID invocationId = UUID.randomUUID();
+    String[] capturedInvocationId = new String[1];
+    SmartWorkflowInputGuardrail guardrail = new SmartWorkflowInputGuardrail() {
+      @Override
+      public GuardrailResult evaluate(String message) {
+        return evaluate(message, null);
+      }
+
+      @Override
+      public GuardrailResult evaluate(String message, String invocationIdParam) {
+        capturedInvocationId[0] = invocationIdParam;
+        return GuardrailResult.allow();
+      }
+    };
+    var adapter = new InputGuardrailAdapter(guardrail);
+    var request = InputGuardrailRequest.builder()
+        .userMessage(UserMessage.from(TextContent.from("hello")))
+        .commonParams(GuardrailRequestParams.builder()
+            .userMessageTemplate("")
+            .variables(Map.of())
+            .invocationContext(InvocationContext.builder()
+                .invocationId(invocationId)
+                .timestamp(Instant.now())
+                .methodName("chat")
+                .interfaceName("ChatAgent")
+                .build())
+            .build())
+        .build();
+
+    adapter.validate(request);
+
+    assertThat(capturedInvocationId[0]).isEqualTo(invocationId.toString());
+  }
+}

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/governance/history/listener/InputGuardrailListener.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/governance/history/listener/InputGuardrailListener.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.axonivy.utils.smart.workflow.governance.history.recorder.GuardrailExecutionRecorder;
-import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailInspectionText;
+import com.axonivy.utils.smart.workflow.guardrails.adapter.GuardrailInspectionText;
 import com.axonivy.utils.smart.workflow.guardrails.pii.PiiDetector;
 
 import dev.langchain4j.guardrail.GuardrailResult.Failure;

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/governance/history/listener/InputGuardrailListener.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/governance/history/listener/InputGuardrailListener.java
@@ -4,9 +4,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.axonivy.utils.smart.workflow.governance.history.recorder.GuardrailExecutionRecorder;
+import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailInspectionText;
 import com.axonivy.utils.smart.workflow.guardrails.pii.PiiDetector;
 
-import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.guardrail.GuardrailResult.Failure;
 import dev.langchain4j.observability.api.event.InputGuardrailExecutedEvent;
 import dev.langchain4j.observability.api.listener.InputGuardrailExecutedListener;
@@ -25,7 +25,7 @@ public class InputGuardrailListener implements InputGuardrailExecutedListener {
     String result = event.result().result().name();
     String rawMessage = Optional.ofNullable(event.request())
         .map(r -> r.userMessage())
-        .map(UserMessage::singleText)
+        .map(GuardrailInspectionText::text)
         .orElse(null);
 
     String message = rawMessage != null ? PiiDetector.detectAndMask(rawMessage).maskedText() : null;

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/adapter/GuardrailInspectionText.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/adapter/GuardrailInspectionText.java
@@ -1,4 +1,4 @@
-package com.axonivy.utils.smart.workflow.guardrails.entity;
+package com.axonivy.utils.smart.workflow.guardrails.adapter;
 
 import java.util.List;
 import java.util.Optional;

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/adapter/InputGuardrailAdapter.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/adapter/InputGuardrailAdapter.java
@@ -2,8 +2,7 @@ package com.axonivy.utils.smart.workflow.guardrails.adapter;
 
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
-
+import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailInspectionText;
 import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailResult;
 import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowInputGuardrail;
 
@@ -20,14 +19,13 @@ public class InputGuardrailAdapter extends AbstractGuardrailAdapter<SmartWorkflo
 
   @Override
   public InputGuardrailResult validate(UserMessage userMessage) {
-    String message = Optional.ofNullable(userMessage).map(UserMessage::singleText).orElse(StringUtils.EMPTY);
-    return doValidate(message);
+    return doValidate(GuardrailInspectionText.text(userMessage));
   }
 
   @Override
   public InputGuardrailResult validate(InputGuardrailRequest request) {
-    String message = Optional.ofNullable(request).map(InputGuardrailRequest::userMessage).map(UserMessage::singleText)
-        .orElse(StringUtils.EMPTY);
+    String message = GuardrailInspectionText.text(
+        Optional.ofNullable(request).map(InputGuardrailRequest::userMessage).orElse(null));
     String invocationId = Optional.ofNullable(request)
         .map(InputGuardrailRequest::requestParams)
         .map(p -> p.invocationContext())

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/adapter/InputGuardrailAdapter.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/adapter/InputGuardrailAdapter.java
@@ -2,7 +2,6 @@ package com.axonivy.utils.smart.workflow.guardrails.adapter;
 
 import java.util.Optional;
 
-import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailInspectionText;
 import com.axonivy.utils.smart.workflow.guardrails.entity.GuardrailResult;
 import com.axonivy.utils.smart.workflow.guardrails.entity.SmartWorkflowInputGuardrail;
 

--- a/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/entity/GuardrailInspectionText.java
+++ b/smart-workflow/src/com/axonivy/utils/smart/workflow/guardrails/entity/GuardrailInspectionText.java
@@ -1,0 +1,49 @@
+package com.axonivy.utils.smart.workflow.guardrails.entity;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import dev.langchain4j.data.message.Content;
+import static dev.langchain4j.data.message.ContentType.AUDIO;
+import static dev.langchain4j.data.message.ContentType.IMAGE;
+import static dev.langchain4j.data.message.ContentType.PDF;
+import static dev.langchain4j.data.message.ContentType.VIDEO;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.UserMessage;
+
+public final class GuardrailInspectionText {
+
+  private static final String FILE_PLACEHOLDER = "<file: %s>";
+
+  private GuardrailInspectionText() {}
+
+  public static String text(UserMessage userMessage) {
+    return Optional.ofNullable(userMessage)
+        .map(UserMessage::contents)
+        .orElseGet(List::of)
+        .stream()
+        .map(GuardrailInspectionText::describe)
+        .filter(part -> !part.isEmpty())
+        .collect(Collectors.joining("\n"));
+  }
+
+  private static String describe(Content content) {
+    if (content instanceof TextContent text
+        && Optional.ofNullable(text).map(TextContent::text).isPresent()) {
+      return text.text();
+    }
+
+    return switch (content.type()) {
+      case IMAGE -> filePlaceholder(IMAGE.name());
+      case PDF -> filePlaceholder(PDF.name());
+      case AUDIO -> filePlaceholder(AUDIO.name());
+      case VIDEO -> filePlaceholder(VIDEO.name());
+      default -> "";
+    };
+  }
+
+  private static String filePlaceholder(String type) {
+    return String.format(FILE_PLACEHOLDER, type);
+  }
+}


### PR DESCRIPTION
When run an agent with type different from text, for example:

```
Extract all text content from this invoice image: <%=in.invoiceStream%>
```

An error will throw when run through input guardrails

<img width="1787" height="1152" alt="image" src="https://github.com/user-attachments/assets/6f307460-2cd3-4b8a-802e-bf07c38319c9" />

---

### Solution

replace the content of different types with placehoder. For example:

```
Extract all text content from this invoice image: <file: IMAGE>
```