### PR TITLE
Convert file upload to primefaces 15

### DIFF
--- a/demo/smart-workflow-supplier-demo/dialog/com/axonivy/utils/ai/components/LegalDocuments/LegalDocuments.xhtml
+++ b/demo/smart-workflow-supplier-demo/dialog/com/axonivy/utils/ai/components/LegalDocuments/LegalDocuments.xhtml
@@ -94,12 +94,14 @@
         widgetVar="#{cc.attrs.uploadWidgetVar}"
         listener="#{cc.attrs.bean.uploadRequiredDocument}"
         auto="true"
-        dragDropSupport="true"
+        dragDrop="true"
         dropZone="req-doc-dropzone"
         update="#{cc.attrs.updateTargets} req-docs-panel"
-        allowTypes="/(\.|\/)((pdf)|(doc)|(docx)|(jpg)|(jpeg)|(png)|(txt)|(md))$/i"
-        accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,.txt,.md"
-        sizeLimit="10485760" />
+        accept=".pdf,.doc,.docx,.jpg,.jpeg,.png,.txt,.md">
+        <p:validateFile
+          allowTypes="/(\.|\/)((pdf)|(doc)|(docx)|(jpg)|(jpeg)|(png)|(txt)|(md))$/i"
+          sizeLimit="10485760" />
+      </p:fileUpload>
 
       <h:panelGroup id="req-docs-panel" layout="block">
 

--- a/demo/smart-workflow-supplier-demo/dialog/com/axonivy/utils/ai/components/SingleLegalDocument/SingleLegalDocument.xhtml
+++ b/demo/smart-workflow-supplier-demo/dialog/com/axonivy/utils/ai/components/SingleLegalDocument/SingleLegalDocument.xhtml
@@ -17,9 +17,11 @@
     listener="#{cc.attrs.bean.uploadRequiredDocument}"
     auto="true"
     update="#{cc.attrs.updateTargets}"
-    allowTypes="/(\.|\/)((pdf)|(txt)|(md)|(doc)|(docx)|(jpg)|(jpeg)|(png))$/i"
-    accept=".pdf,.txt,.md,.doc,.docx,.jpg,.jpeg,.png"
-    sizeLimit="10485760" />
+    accept=".pdf,.txt,.md,.doc,.docx,.jpg,.jpeg,.png">
+    <p:validateFile
+      allowTypes="/(\.|\/)((pdf)|(txt)|(md)|(doc)|(docx)|(jpg)|(jpeg)|(png))$/i"
+      sizeLimit="10485760" />
+  </p:fileUpload>
 
   <div class="so-doc-row so-doc-row--flat m-0 surface-0">
 

--- a/demo/smart-workflow-supplier-demo/dialog/com/axonivy/utils/ai/components/SupplierAiAssistant/SupplierAiAssistant.xhtml
+++ b/demo/smart-workflow-supplier-demo/dialog/com/axonivy/utils/ai/components/SupplierAiAssistant/SupplierAiAssistant.xhtml
@@ -194,15 +194,13 @@
                 listener="#{cc.attrs.uploadListener}"
                 mode="advanced"
                 auto="true"
-                dragDropSupport="false"
+                dragDrop="false"
                 process="@this"
                 update="@all"
-                allowTypes="/(\.|\/)(txt|md|pdf)$/"
                 accept=".txt,.md,.pdf"
-                sizeLimit="5242880"
-                invalidFileMessage="#{ivy.cms.co('/Dialogs/com/axonivy/utils/smart/workflow/demo/erp/supplier/onboarding/components/SupplierAiAssistant/InvalidFileMessage')}"
-                invalidSizeMessage="#{ivy.cms.co('/Dialogs/com/axonivy/utils/smart/workflow/demo/erp/supplier/onboarding/components/SupplierAiAssistant/InvalidSizeMessage')}"
-                styleClass="hidden" />
+                styleClass="hidden">
+                <p:validateFile allowTypes="/(\.|\/)(txt|md|pdf)$/" sizeLimit="5242880" />
+              </p:fileUpload>
               <p:commandButton id="assistant-upload-trigger"
                 type="button"
                 icon="ti ti-file-upload"

--- a/smart-workflow-demo/dialog/com/axonivy/utils/smart/workflow/demo/rag/RagDemo/Step2Upload.xhtml
+++ b/smart-workflow-demo/dialog/com/axonivy/utils/smart/workflow/demo/rag/RagDemo/Step2Upload.xhtml
@@ -51,9 +51,10 @@
           <p:fileUpload auto="true" multiple="false" accept=".txt,.md,.pdf"
             listener="#{logic.handleFileUpload}"
             update="step2-panel rag-footer"
-            allowTypes="/(\.|\/)(txt|md|pdf)$/"
             label="#{ivy.cms.co('/Dialogs/com/axonivy/utils/smart/workflow/demo/rag/RagDemo/ChooseFileLabel')}"
-            styleClass="rag-file-upload" />
+            styleClass="rag-file-upload">
+            <p:validateFile allowTypes="/(\.|\/)(txt|md|pdf)$/" />
+          </p:fileUpload>
         </div>
       </div>
 

--- a/smart-workflow-demo/dialog/com/axonivy/utils/smart/workflow/demo/shopping/product/ProductCreation/ProductCreation.xhtml
+++ b/smart-workflow-demo/dialog/com/axonivy/utils/smart/workflow/demo/shopping/product/ProductCreation/ProductCreation.xhtml
@@ -49,10 +49,11 @@
                               styleClass="upload-component doc-upload"
                               onupload="updateUploadStatus('doc', 'success')"
                               onerror="updateUploadStatus('doc', 'error')"
-                              dragDropSupport="true"
-                              allowTypes="/(\.|\/)(pdf|md)$/"
+                              dragDrop="true"
                               uploadLabel="#{ivy.cms.co('/Dialogs/com/axonivy/utils/smart/workflow/demo/shopping/product/ProductCreation/UploadDocument')}"
-                              cancelLabel="#{ivy.cms.co('/Labels/Cancel')}" />
+                              cancelLabel="#{ivy.cms.co('/Labels/Cancel')}">
+                  <p:validateFile allowTypes="/(\.|\/)(pdf|md)$/" />
+                </p:fileUpload>
                 
                 <!-- Document Upload Status Indicator -->
                 <h:panelGroup id="doc-upload-status" layout="block" styleClass="mt-3" rendered="#{not empty data.productInfo}">
@@ -115,10 +116,11 @@
                               styleClass="upload-component image-upload"
                               onupload="updateUploadStatus('image', 'success')"
                               onerror="updateUploadStatus('image', 'error')"
-                              dragDropSupport="true"
-                              allowTypes="/(\.|\/)(jpg)$/"
+                              dragDrop="true"
                               uploadLabel="#{ivy.cms.co('/Dialogs/com/axonivy/utils/smart/workflow/demo/shopping/product/ProductCreation/UploadImage')}"
-                              cancelLabel="#{ivy.cms.co('/Labels/Cancel')}" />
+                              cancelLabel="#{ivy.cms.co('/Labels/Cancel')}">
+                  <p:validateFile allowTypes="/(\.|\/)(jpg)$/" />
+                </p:fileUpload>
 
                 <!-- Image Upload Status Indicator -->
                 <h:panelGroup id="img-upload-status" layout="block" styleClass="mt-3" rendered="#{not empty data.imageBase64}">


### PR DESCRIPTION
In the supplier demo project, we got error related to `sizeLimit`

<img width="1466" height="747" alt="Screenshot 2026-08-21 103045" src="https://github.com/user-attachments/assets/eee57625-801d-4381-afd0-5328bcb7d969" />

Root cause (verified against primefaces-15.0.17-jakarta.jar's taglib):

- PrimeFaces 15 removed sizeLimit, allowTypes, and fileLimit from p:fileUpload and moved them to a new nested validator <p:validateFile> (validator id primefaces.File).
- dragDropSupport was also renamed to dragDrop.

See https://primefaces.github.io/primefaces/15_0_0/#/../migrationguide/15_0_0?id=fileupload