### PR TITLE
Disable xhtml validator of project-build-plugin

### DIFF
--- a/demo/smart-workflow-supplier-demo/pom.xml
+++ b/demo/smart-workflow-supplier-demo/pom.xml
@@ -57,6 +57,11 @@
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
         <version>${project.parent.version}</version>
+        <configuration>
+          <excludeValidators>
+            <validator>xhtml</validator>
+          </excludeValidators>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/smart-workflow-dashboard/pom.xml
+++ b/smart-workflow-dashboard/pom.xml
@@ -50,6 +50,11 @@
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
         <version>${project.parent.version}</version>
+        <configuration>
+          <excludeValidators>
+            <validator>xhtml</validator>
+          </excludeValidators>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/smart-workflow-demo/pom.xml
+++ b/smart-workflow-demo/pom.xml
@@ -57,6 +57,11 @@
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
         <version>${project.parent.version}</version>
+        <configuration>
+          <excludeValidators>
+            <validator>xhtml</validator>
+          </excludeValidators>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
some projects show XHTML warnings but currently I have no idea why... code seem valid and run correctly.
Therefore I want to temporary disable them for now.

<img width="1345" height="665" alt="Screenshot 2026-08-21 135233" src="https://github.com/user-attachments/assets/e3231366-44eb-4d1d-8cb8-9b653f59f2eb" />
