### PR TITLE
Dedicated POM name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.axonivy.utils.ai</groupId>
-  <name>smart-workflow</name>
   <artifactId>smart-workflow-modules</artifactId>
   <version>14.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>


### PR DESCRIPTION
overriding the default project name is an anti-pattern, always make me think which artifact is what in CI pipelines and also in the vscode maven view

before:
<img width="1417" height="1361" alt="name-override-antipattern" src="https://github.com/user-attachments/assets/bb92fc3f-1bff-4508-a584-d52869fd67a2" />

---

after:
<img width="1417" height="1361" alt="Selection_376" src="https://github.com/user-attachments/assets/9878151d-9961-4029-8bd7-8c2987de03dd" />

