### PR TITLE
Initialize document workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,80 @@
+name: Docs-Build
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'smart-workflow-document/**'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'doc/**'
+      - 'smart-workflow-document/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: smart-workflow-document/package-lock.json
+
+      - name: Install dependencies
+        working-directory: smart-workflow-document
+        run: npm ci
+
+      - name: Type check
+        working-directory: smart-workflow-document
+        run: npm run typecheck
+
+      - name: Build site
+        working-directory: smart-workflow-document
+        run: npm run build
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: smart-workflow-document/build
+
+      - name: Upload PR preview build
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-preview-pr-${{ github.event.pull_request.number }}
+          path: smart-workflow-document/build
+          retention-days: 14
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
### When the workflow runs

Documentation workflow that build the Docusaurus project `smart-workflow-document` and deploy to Github Page. This workflow runs:

- When a pull request is created/updated → build only
- When pushed to master or manually triggered → build + deploy

and when one of these paths changes:

```
smart-workflow-document/**
.github/workflows/docs.yml
```
This avoids unnecessary documentation builds when unrelated files are changed.

### Permissions
`contents: read`: Allows the workflow to read the repository.
`pages: write`: Allows the workflow to deploy the generated site to GitHub Pages.
`id-token: write`: Used by GitHub Pages deployment for authentication.

### Artifacts

For pull requests, the generated documentation build is uploaded as a GitHub Actions artifact and is kept for 14 days.